### PR TITLE
Fixed typo: outpuf -> output

### DIFF
--- a/pdfsam-fx/src/main/java/org/pdfsam/ui/io/DestinationPane.java
+++ b/pdfsam-fx/src/main/java/org/pdfsam/ui/io/DestinationPane.java
@@ -43,7 +43,7 @@ class DestinationPane extends VBox {
         this.destination = destination;
         overwrite.setSelected(false);
         overwrite.setTooltip(new Tooltip(DefaultI18nContext.getInstance().i18n(
-                "Tick the box if you want to overwrite the outpuf files if they already exist.")));
+                "Tick the box if you want to overwrite the output files if they already exist.")));
 
         destination.getStyleClass().addAll(Style.VITEM.css());
         getChildren().addAll(destination, overwrite);


### PR DESCRIPTION
Hi Andrea,
I found and fixed a small typo while I was translating PDFsam to the Basque language:
>outpuf -> output

Have a nice day!