### PR TITLE
Fix German translation

### DIFF
--- a/pdfsam-i18n/po/de.po
+++ b/pdfsam-i18n/po/de.po
@@ -165,7 +165,7 @@ msgid "Social"
 msgstr "Sozial"
 
 msgid "Premium features"
-msgstr ""
+msgstr "Premium-Features"
 
 msgid "Manually selected"
 msgstr "Manuell ausgewählt"
@@ -236,12 +236,14 @@ msgstr ""
 "PDFsam fragt, ein- oder ausschalten"
 
 msgid "Show premium features"
-msgstr ""
+msgstr "Zeige Premium-Features"
 
 msgid ""
 "Set whether the application should fetch and show premium features "
 "description in the modules dashboard"
 msgstr ""
+"Festlegen, ob die Anwendung die Beschreibung der Premium-Features im "
+"Dashboard des Moduls anzeigen soll"
 
 msgid "Use the selected PDF document directory as output directory"
 msgstr ""
@@ -433,13 +435,13 @@ msgid "Checking for updates"
 msgstr "Nach Aktualisierungen wird gesucht"
 
 msgid "Unable to retrieve premium features description"
-msgstr ""
+msgstr "Kann die Beschreibung der Premium-Features nicht laden"
 
 msgid "Fetching premium modules"
-msgstr ""
+msgstr "Hole Premium-Module"
 
 msgid "Unable to retrieve premium modules"
-msgstr ""
+msgstr "Kann die Premium-Module nicht laden"
 
 msgid "Fetching latest news"
 msgstr "Die neuesten Nachrichten werden abgerufen"

--- a/pdfsam-i18n/po/de.po
+++ b/pdfsam-i18n/po/de.po
@@ -578,7 +578,7 @@ msgid "KB"
 msgstr "KB"
 
 msgid "Alternate Mix"
-msgstr "Alternativer Mix"
+msgstr "Alternierendes Mischen"
 
 msgid ""
 "Merge two or more PDF documents taking pages alternately in natural or "


### PR DESCRIPTION
The German translation of one feature in the main menu was misleading.

Also, added a few translations that were missing.