### PR TITLE
Typo in translation

### DIFF
--- a/pdfsam-i18n/po/nl.po
+++ b/pdfsam-i18n/po/nl.po
@@ -128,7 +128,7 @@ msgid "Contribute"
 msgstr "Bijdragen"
 
 msgid "Fork PDFsam on GitHub"
-msgstr "Fork PFDsam op GitHub"
+msgstr "Fork PDFsam op GitHub"
 
 msgid "Translate"
 msgstr "Vertalen"


### PR DESCRIPTION
Translation contains PFD in stead of PDF -- have no access to translator site, so signalling via Github