### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 sudo: false
-
+cache:
+  directories:
+  - $HOME/.m2
 matrix:
   include:
     # Ubuntu Linux (xenial) / Open DK 11 / Headed (Glass Robot) / HiDPI


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.