### PR TITLE
Introduce clearDragHover method for drag hover state resetting

### DIFF
--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/SelectionTable.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/SelectionTable.java
@@ -393,6 +393,7 @@ public class SelectionTable extends TableView<SelectionTableRowData> implements 
     }
 
     private void onDragExited(DragEvent e) {
+        clearDragHover();
         placeHolder.setDisable(true);
         e.consume();
     }
@@ -421,7 +422,7 @@ public class SelectionTable extends TableView<SelectionTableRowData> implements 
         getSortOrder().clear();
         getItems().addAll(dropIndex, toDrop);
         focus.map(getItems()::indexOf).ifPresent(getFocusModel()::focus);
-        hoverIndex.setValue(-1);
+        clearDragHover();
         this.sort();
 
         loadEvent.getDocuments().stream().findFirst().ifPresent(
@@ -557,5 +558,9 @@ public class SelectionTable extends TableView<SelectionTableRowData> implements 
         }
 
         return -1;
+    }
+    
+    private void clearDragHover() {
+        hoverIndex.setValue(-1);
     }
 }


### PR DESCRIPTION
Clears `hoverIndex` on drag exit events and `onLoadDocumentsRequest` that occurs after drag dropped events. Previously, the drag hover resetting was only happening after the drag dropped events. This change ensures that even when a drag drop doesn't occur after a drag entry, the drag-hover pseudo gets reset.