### PR TITLE
Allow unlocking multiple documents at once via selection and context menu

### DIFF
--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/PasswordFieldPopup.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/PasswordFieldPopup.java
@@ -44,7 +44,7 @@ import static org.pdfsam.i18n.I18nContext.i18n;
 public class PasswordFieldPopup extends PopupControl implements ToolBound {
     private String toolBinding = StringUtils.EMPTY;
     private final PasswordFieldPopupContent content = new PasswordFieldPopupContent();
-    private PdfDocumentDescriptor pdfDescriptor;
+    private PdfDocumentDescriptor[] pdfDescriptors;
 
     public PasswordFieldPopup(String toolBinding) {
         this.toolBinding = defaultString(toolBinding);
@@ -69,8 +69,8 @@ public class PasswordFieldPopup extends PopupControl implements ToolBound {
         return new PasswordFieldPopupSkin(this);
     }
 
-    public void showFor(Node owner, PdfDocumentDescriptor pdfDescriptor, double anchorX, double anchorY) {
-        this.pdfDescriptor = pdfDescriptor;
+    public void showFor(Node owner, double anchorX, double anchorY, PdfDocumentDescriptor... pdfDescriptors) {
+        this.pdfDescriptors = pdfDescriptors;
         this.show(owner, anchorX, anchorY);
     }
 
@@ -98,11 +98,13 @@ public class PasswordFieldPopup extends PopupControl implements ToolBound {
         }
 
         public void requestLoad() {
-            if (pdfDescriptor != null) {
-                pdfDescriptor.setPassword(passwordField.getText());
-                var loadEvent = new PdfLoadRequest(toolBinding());
-                loadEvent.add(pdfDescriptor);
-                eventStudio().broadcast(loadEvent);
+            if (pdfDescriptors != null) {
+                for (PdfDocumentDescriptor desc : pdfDescriptors) {
+                    desc.setPassword(passwordField.getText());
+                    var loadEvent = new PdfLoadRequest(toolBinding());
+                    loadEvent.add(desc);
+                    eventStudio().broadcast(loadEvent);
+                }
             }
             passwordField.clear();
             hide();

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/ShowPasswordFieldPopupRequest.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/ShowPasswordFieldPopupRequest.java
@@ -21,6 +21,7 @@ package org.pdfsam.ui.components.selection;
 import javafx.scene.layout.Region;
 import org.pdfsam.model.pdf.PdfDocumentDescriptor;
 
+import static org.sejda.commons.util.RequireUtils.requireArg;
 import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
 
 /**
@@ -28,10 +29,10 @@ import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
  *
  * @author Andrea Vacondio
  */
-public record ShowPasswordFieldPopupRequest(PdfDocumentDescriptor pdfDescriptor, Region requestingNode) {
+public record ShowPasswordFieldPopupRequest(Region requestingNode, PdfDocumentDescriptor... pdfDescriptors) {
 
     public ShowPasswordFieldPopupRequest {
-        requireNotNullArg(pdfDescriptor, "Cannot show password field popup for a null document");
+        requireArg(pdfDescriptors != null && pdfDescriptors.length > 0, "Cannot show password field popup for no document");
         requireNotNullArg(requestingNode, "Cannot show password field popup for a null node");
     }
 

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/LoadingColumn.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/LoadingColumn.java
@@ -104,7 +104,7 @@ public class LoadingColumn extends BaseToolBound implements SelectionTableColumn
                     MouseEvent.MOUSE_CLICKED,
                     e -> {
                         if (getItem() == ENCRYPTED) {
-                            eventStudio().broadcast(new ShowPasswordFieldPopupRequest(getPdfDocumentDescriptor(), this),
+                            eventStudio().broadcast(new ShowPasswordFieldPopupRequest(this, getPdfDocumentDescriptor()),
                                     toolBinding());
                         } else if (getItem() == WITH_ERRORS) {
                             eventStudio().broadcast(new ShowLogMessagesRequest());

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/single/SingleSelectionPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/single/SingleSelectionPane.java
@@ -236,7 +236,7 @@ public class SingleSelectionPane extends VBox implements ToolBound, PdfDocumentD
                         encryptionIndicator.getHeight() / 1.5);
                 double anchorX = Math.round(owner.getX() + scene.getX() + nodeCoord.getX() + 2);
                 double anchorY = Math.round(owner.getY() + scene.getY() + nodeCoord.getY() + 2);
-                passwordPopup.showFor(this, descriptor, anchorX, anchorY);
+                passwordPopup.showFor(this, anchorX, anchorY, descriptor);
             }
         }
     }

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/PasswordFieldPopupTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/PasswordFieldPopupTest.java
@@ -56,7 +56,7 @@ public class PasswordFieldPopupTest {
         Button button = new Button("press");
         PasswordFieldPopup victim = new PasswordFieldPopup("module");
         victim.setId("victim");
-        button.setOnAction(e -> victim.showFor(button, pdfDescriptor, 0, 0));
+        button.setOnAction(e -> victim.showFor(button, 0, 0, pdfDescriptor));
         Scene scene = new Scene(new HBox(button));
         stage.setScene(scene);
         stage.show();

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/ShowPasswordFieldPopupRequestTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/ShowPasswordFieldPopupRequestTest.java
@@ -33,17 +33,19 @@ public class ShowPasswordFieldPopupRequestTest {
 
     @Test
     public void nullDescriptor() {
-        assertThrows(IllegalArgumentException.class, () -> new ShowPasswordFieldPopupRequest(null, new Region()));
+        assertThrows(IllegalArgumentException.class, () -> new ShowPasswordFieldPopupRequest(new Region(),
+                (PdfDocumentDescriptor[]) null));
     }
 
     @Test
     public void nullRegion() {
         assertThrows(IllegalArgumentException.class,
-                () -> new ShowPasswordFieldPopupRequest(mock(PdfDocumentDescriptor.class), null));
+                () -> new ShowPasswordFieldPopupRequest(null, mock(PdfDocumentDescriptor.class)));
     }
 
     @Test
     public void nullBoth() {
-        assertThrows(IllegalArgumentException.class, () -> new ShowPasswordFieldPopupRequest(null, null));
+        assertThrows(IllegalArgumentException.class, () -> new ShowPasswordFieldPopupRequest(null,
+                (PdfDocumentDescriptor[]) null));
     }
 }


### PR DESCRIPTION
Minor changes to the UI and request to allow unlocking more than one password-protected PDFs at once. The option is available upon selection in a context menu

Addresses issue #519