### PR TITLE
Add option to choose the application font

### DIFF
--- a/pdfsam-core/src/main/java/org/pdfsam/core/context/StringPersistentProperty.java
+++ b/pdfsam-core/src/main/java/org/pdfsam/core/context/StringPersistentProperty.java
@@ -38,6 +38,7 @@ public enum StringPersistentProperty implements PersistentProperty<String> {
     STARTUP_MODULE(() -> ""),
     LOCALE(() -> System.getProperty(LOCALE_PROP)),
     THEME(() -> System.getProperty(THEME_PROP)),
+    FONT(() -> ""),
     FONT_SIZE(() -> ""),
     PDF_VERSION(() -> {
         var version = System.getProperty(PDFVERSION_PROP, PdfVersion.VERSION_1_5.name());

--- a/pdfsam-gui/src/main/java/org/pdfsam/gui/components/content/preference/PreferenceAppearencePane.java
+++ b/pdfsam-gui/src/main/java/org/pdfsam/gui/components/content/preference/PreferenceAppearencePane.java
@@ -44,6 +44,7 @@ class PreferenceAppearencePane extends GridPane {
     public PreferenceAppearencePane(@Named("localeCombo") PreferenceComboBox<ComboItem<String>> localeCombo,
             @Named("startupToolCombo") PreferenceComboBox<ComboItem<String>> startupTool,
             @Named("themeCombo") PreferenceComboBox<ComboItem<String>> themeCombo,
+            @Named("fontFamilyCombo") PreferenceComboBox<ComboItem<String>> fontFamilyCombo,
             @Named("fontSizeCombo") PreferenceComboBox<ComboItem<String>> fontSizeCombo) {
         add(new Label(i18n().tr("Language:")), 0, 0);
         i18n().getSupported().stream().map(ComboItem::fromLocale).sorted(Comparator.comparing(ComboItem::description))
@@ -69,11 +70,17 @@ class PreferenceAppearencePane extends GridPane {
         add(themeCombo, 1, 2);
         add(helpIcon(i18n().tr("Set the application theme")), 2, 2);
 
-        add(new Label(i18n().tr("Font size:")), 0, 3);
+        add(new Label(i18n().tr("Font:")), 0, 3);
+        fontFamilyCombo.setMaxWidth(Double.POSITIVE_INFINITY);
+        setFillWidth(fontFamilyCombo, true);
+        add(fontFamilyCombo, 1, 3);
+        add(helpIcon(i18n().tr("Sets the application font")), 2, 3);
+
+        add(new Label(i18n().tr("Font size:")), 0, 4);
         fontSizeCombo.setMaxWidth(Double.POSITIVE_INFINITY);
         setFillWidth(fontSizeCombo, true);
-        add(fontSizeCombo, 1, 3);
-        add(helpIcon(i18n().tr("Set the application font size")), 2, 3);
+        add(fontSizeCombo, 1, 4);
+        add(helpIcon(i18n().tr("Set the application font size")), 2, 4);
         
         getStyleClass().addAll(Style.CONTAINER.css());
         getStyleClass().addAll(Style.GRID.css());

--- a/pdfsam-gui/src/main/java/org/pdfsam/gui/components/content/preference/PreferenceConfig.java
+++ b/pdfsam-gui/src/main/java/org/pdfsam/gui/components/content/preference/PreferenceConfig.java
@@ -19,8 +19,8 @@
 package org.pdfsam.gui.components.content.preference;
 
 import jakarta.inject.Named;
+import javafx.scene.text.Font;
 import javafx.util.Subscription;
-import org.pdfsam.core.context.StringPersistentProperty;
 import org.pdfsam.core.support.validation.Validators;
 import org.pdfsam.gui.components.content.log.MaxLogRowsChangedEvent;
 import org.pdfsam.gui.theme.Themes;
@@ -54,7 +54,9 @@ import static org.pdfsam.core.context.BooleanPersistentProperty.SAVE_PWD_IN_WORK
 import static org.pdfsam.core.context.BooleanPersistentProperty.SAVE_WORKSPACE_ON_EXIT;
 import static org.pdfsam.core.context.BooleanPersistentProperty.SMART_OUTPUT;
 import static org.pdfsam.core.context.IntegerPersistentProperty.LOGVIEW_ROWS_NUMBER;
+import static org.pdfsam.core.context.StringPersistentProperty.FONT;
 import static org.pdfsam.core.context.StringPersistentProperty.FONT_SIZE;
+import static org.pdfsam.core.context.StringPersistentProperty.LOCALE;
 import static org.pdfsam.core.context.StringPersistentProperty.PDF_VERSION;
 import static org.pdfsam.core.context.StringPersistentProperty.STARTUP_MODULE;
 import static org.pdfsam.core.context.StringPersistentProperty.THEME;
@@ -75,7 +77,7 @@ public class PreferenceConfig {
     @Provides
     @Named("localeCombo")
     public PreferenceComboBox<ComboItem<String>> localeCombo() {
-        return new PreferenceComboBox<>(StringPersistentProperty.LOCALE);
+        return new PreferenceComboBox<>(LOCALE);
     }
 
     @Provides
@@ -112,6 +114,18 @@ public class PreferenceConfig {
     }
 
     @Provides
+    @Named("fontFamilyCombo")
+    public PreferenceComboBox<ComboItem<String>> fontFamilyCombo() {
+        PreferenceComboBox<ComboItem<String>> fontFamilyCombo = new PreferenceComboBox<>(FONT);
+        fontFamilyCombo.setId("fontFamilyCombo");
+        fontFamilyCombo.getItems().add(new ComboItem<>("", i18n().tr("Default")));
+        Font.getFamilies().forEach(f -> fontFamilyCombo.getItems().add(new ComboItem<>(f, f)));
+        fontFamilyCombo.getItems().remove(new ComboItem<>("System", ""));
+        fontFamilyCombo.setValue(keyWithEmptyValue(app().persistentSettings().get(FONT).orElse("")));
+        return fontFamilyCombo;
+    }
+
+    @Provides
     @Named("fontSizeCombo")
     public PreferenceComboBox<ComboItem<String>> fontSizeCombo() {
         PreferenceComboBox<ComboItem<String>> fontSizeCombo = new PreferenceComboBox<>(FONT_SIZE);
@@ -131,7 +145,7 @@ public class PreferenceConfig {
                 .filter(v -> v.getVersion() > PdfVersion.VERSION_1_2.getVersion()).map(DefaultPdfVersionComboItem::new)
                 .toList());
         //select if present in the settings
-        app().persistentSettings().get(StringPersistentProperty.PDF_VERSION).map(PdfVersion::valueOf)
+        app().persistentSettings().get(PDF_VERSION).map(PdfVersion::valueOf)
                 .flatMap(v -> pdfVersionCombo.getItems().stream().filter(i -> i.key() == v).findFirst())
                 .ifPresent(i -> pdfVersionCombo.getSelectionModel().select(i));
         return pdfVersionCombo;

--- a/pdfsam-gui/src/test/java/org/pdfsam/gui/components/content/preference/PreferenceAppearencePaneTest.java
+++ b/pdfsam-gui/src/test/java/org/pdfsam/gui/components/content/preference/PreferenceAppearencePaneTest.java
@@ -64,9 +64,15 @@ public class PreferenceAppearencePaneTest {
         var startupModuleCombo = new PreferenceComboBox<ComboItem<String>>(StringPersistentProperty.STARTUP_MODULE,
                 appContext);
         var themeCombo = new PreferenceComboBox<ComboItem<String>>(StringPersistentProperty.THEME, appContext);
+        var fontFamilyCombo = new PreferenceComboBox<ComboItem<String>>(StringPersistentProperty.FONT, appContext);
         var fontSizeCombo = new PreferenceComboBox<ComboItem<String>>(StringPersistentProperty.FONT_SIZE, appContext);
-        PreferenceAppearencePane victim = new PreferenceAppearencePane(localeCombo, startupModuleCombo, themeCombo,
-                fontSizeCombo);
+        PreferenceAppearencePane victim = new PreferenceAppearencePane(
+                localeCombo,
+                startupModuleCombo,
+                themeCombo,
+                fontFamilyCombo,
+                fontSizeCombo
+        );
         victim.setId("victim");
         Scene scene = new Scene(new HBox(victim));
         stage.setScene(scene);


### PR DESCRIPTION
This PR adds an entry in the application's settings which allows the user to choose the font family through a combo box. The list of fonts is taken from the system at the time the application is started.

Unfortunately, at the moment, JavaFX offers no API to get the font used by the OS, so the best solution as of now is to let the user choose the font.

Addresses issue #717