### PR TITLE
WIP: Ask the user to save the workspace if it changed before closing the app

### DIFF
--- a/pdfsam-gui/src/main/java/org/pdfsam/gui/components/dialog/SaveWorkspaceConfirmationDialog.java
+++ b/pdfsam-gui/src/main/java/org/pdfsam/gui/components/dialog/SaveWorkspaceConfirmationDialog.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the PDF Split And Merge source code
+ * Created on 12/08/2025
+ * Copyright 2025 by Sober Lemur S.r.l. (info@soberlemur.com).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pdfsam.gui.components.dialog;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import javafx.stage.Stage;
+
+import static org.pdfsam.i18n.I18nContext.i18n;
+
+/**
+ * @author Alessandro Parisi
+ */
+public class SaveWorkspaceConfirmationDialog extends ConfirmationDialog {
+    @Inject
+    public SaveWorkspaceConfirmationDialog(@Named("primaryStage") Stage stage) {
+        super(DialogStyle.QUESTION, stage, i18n().tr("Yes"), i18n().tr("No"));
+        this.title(i18n().tr("Workspace")).messageTitle(i18n().tr("Workspace has changed"))
+                .messageContent(i18n().tr("Do you want to save it?"));
+    }
+}

--- a/pdfsam-gui/src/main/java/org/pdfsam/gui/components/dialog/SaveWorkspaceConfirmationDialogController.java
+++ b/pdfsam-gui/src/main/java/org/pdfsam/gui/components/dialog/SaveWorkspaceConfirmationDialogController.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the PDF Split And Merge source code
+ * Created on 12/08/2025
+ * Copyright 2025 by Sober Lemur S.r.l. (info@soberlemur.com).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pdfsam.gui.components.dialog;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import org.pdfsam.eventstudio.annotation.EventListener;
+import org.pdfsam.injector.Auto;
+import org.pdfsam.model.ui.workspace.ConfirmSaveWorkspaceRequest;
+import org.pdfsam.model.ui.workspace.SaveWorkspaceRequest;
+
+import static org.pdfsam.eventstudio.StaticStudio.eventStudio;
+
+/**
+ * @author Alessandro Parisi
+ */
+@Auto
+public class SaveWorkspaceConfirmationDialogController {
+
+    private final Provider<SaveWorkspaceConfirmationDialog> dialog;
+
+    @Inject
+    public SaveWorkspaceConfirmationDialogController(Provider<SaveWorkspaceConfirmationDialog> dialog) {
+        this.dialog = dialog;
+        eventStudio().addAnnotatedListeners(this);
+    }
+
+    @EventListener
+    public void request(ConfirmSaveWorkspaceRequest event) {
+        if (dialog.get().response())
+            eventStudio().broadcast(new SaveWorkspaceRequest(event.workspace()));
+    }
+}
+

--- a/pdfsam-gui/src/main/java/org/pdfsam/gui/configuration/PdfsamConfig.java
+++ b/pdfsam-gui/src/main/java/org/pdfsam/gui/configuration/PdfsamConfig.java
@@ -34,6 +34,7 @@ import org.pdfsam.gui.components.dialog.CreateOutputDirectoryDialogController;
 import org.pdfsam.gui.components.dialog.LenientTaskExecutionDialogController;
 import org.pdfsam.gui.components.dialog.OpenWithDialogController;
 import org.pdfsam.gui.components.dialog.OverwriteDialogController;
+import org.pdfsam.gui.components.dialog.SaveWorkspaceConfirmationDialogController;
 import org.pdfsam.gui.components.dnd.FilesDropController;
 import org.pdfsam.gui.components.info.InfoStageController;
 import org.pdfsam.gui.components.notification.NotificationsController;
@@ -50,7 +51,8 @@ import org.pdfsam.injector.Provides;
 @Components({ NativeOpenFileController.class, NativeOpenUrlController.class, WindowStatusController.class,
         PlaySoundController.class, NotificationsController.class, InfoStageController.class,
         OpenWithDialogController.class, OverwriteDialogController.class, CreateOutputDirectoryDialogController.class,
-        ClearToolConfirmationDialogController.class, LenientTaskExecutionDialogController.class,
+        ClearToolConfirmationDialogController.class, SaveWorkspaceConfirmationDialogController.class,
+        LenientTaskExecutionDialogController.class,
         FilesDropController.class, AppContentController.class, RunAcceleratorController.class, AboutContentItem.class,
         PreferenceContentItem.class, HomeContentItem.class, LogContentItem.class })
 public class PdfsamConfig {

--- a/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/ConfirmSaveWorkspaceRequest.java
+++ b/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/ConfirmSaveWorkspaceRequest.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the PDF Split And Merge source code
+ * Created on 12/08/2025
+ * Copyright 2025 by Sober Lemur S.r.l. (info@soberlemur.com).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pdfsam.model.ui.workspace;
+
+import java.io.File;
+
+/**
+ * @author Alessandro Parisi
+ */
+public record ConfirmSaveWorkspaceRequest(File workspace) {}

--- a/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/WorkspaceFile.java
+++ b/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/WorkspaceFile.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the PDF Split And Merge source code
+ * Created on 12/08/2025
+ * Copyright 2025 by Sober Lemur S.r.l. (info@soberlemur.com).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pdfsam.model.ui.workspace;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * @author Alessandro Parisi
+ */
+public class WorkspaceFile {
+    private final File file;
+    private long hash = -1L;
+
+    public WorkspaceFile(File file) {
+        this.file = file;
+    }
+
+    private void computeHash() {
+        try {
+            hash = FileUtils.checksumCRC32(file);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public File file() {
+        return file;
+    }
+
+    public long hash() {
+        if (hash == -1L) {
+            computeHash();
+        }
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        WorkspaceFile that = (WorkspaceFile) o;
+        return hash() == that.hash() && Objects.equals(file, that.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(file, hash());
+    }
+}

--- a/pdfsam-service/src/main/java/org/pdfsam/service/ui/DefaultWorkspaceService.java
+++ b/pdfsam-service/src/main/java/org/pdfsam/service/ui/DefaultWorkspaceService.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -50,12 +51,17 @@ public class DefaultWorkspaceService implements WorkspaceService {
         requireNotNullArg(destination, "Destination file cannot be null");
         LOG.debug(i18n().tr("Saving workspace data to {0}", destination.getAbsolutePath()));
         try {
-            objectMapper.writeValue(destination, data);
+            writeToFile(data, destination);
             LOG.info(i18n().tr("Workspace saved"));
         } catch (Exception e) {
             // make it unchecked
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void writeToFile(Map<String, Map<String, String>> data, File destination) throws IOException {
+        objectMapper.writeValue(destination, data);
     }
 
     @Override

--- a/pdfsam-service/src/main/java/org/pdfsam/service/ui/WorkspaceService.java
+++ b/pdfsam-service/src/main/java/org/pdfsam/service/ui/WorkspaceService.java
@@ -19,6 +19,7 @@
 package org.pdfsam.service.ui;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -39,6 +40,8 @@ public interface WorkspaceService {
      *             in case of error
      */
     void saveWorkspace(Map<String, Map<String, String>> data, File destination);
+
+    void writeToFile(Map<String, Map<String, String>> data, File destination) throws IOException;
 
     /**
      * Loads the workspace from the given file


### PR DESCRIPTION
This PR addresses the issue #428.
When a workspace is loaded, and it changes due to the user's actions, it would be nice to prompt the user if he wants to save it before exiting.

For now, the PR only implements such checks, but ideally we should also take a look at the "Save default workspace on exit" setting.
The idea would be to rework it and apply to the loaded workspace in general, maybe as a combo box with three choices:
- Never save
- Always save
- Prompt the user (default)