### PR TITLE
POC: Rework workspace API

### DIFF
--- a/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/LoadWorkspaceResponse.java
+++ b/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/LoadWorkspaceResponse.java
@@ -18,26 +18,10 @@ package org.pdfsam.model.ui.workspace;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
-
 /**
  * Response for a workspace load request
  *
  * @author Andrea Vacondio
  */
-public record LoadWorkspaceResponse(File workspace, Map<String, Map<String, String>> data) {
-    public LoadWorkspaceResponse(File workspace, Map<String, Map<String, String>> data) {
-        requireNotNullArg(workspace, "Workspace file cannot be null");
-        this.workspace = workspace;
-        this.data = ofNullable(data).orElseGet(HashMap::new);
-    }
-
-    public Map<String, String> getData(String tool) {
-        return this.data.computeIfAbsent(tool, (k) -> new HashMap<>());
-    }
+public record LoadWorkspaceResponse(WorkspaceData data) {
 }

--- a/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/RestorableView.java
+++ b/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/RestorableView.java
@@ -18,6 +18,8 @@
  */
 package org.pdfsam.model.ui.workspace;
 
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
+
 import java.util.Map;
 
 /**
@@ -40,5 +42,5 @@ public interface RestorableView {
      * 
      * @param data
      */
-    void restoreStateFrom(Map<String, String> data);
+    void restoreStateFrom(ToolData data);
 }

--- a/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/WorkspaceData.java
+++ b/pdfsam-model/src/main/java/org/pdfsam/model/ui/workspace/WorkspaceData.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of the PDF Split And Merge source code
+ * Created on 19/08/2025
+ * Copyright 2025 by Sober Lemur S.r.l. (info@soberlemur.com).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pdfsam.model.ui.workspace;
+
+import org.pdfsam.model.tool.ToolBound;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+/**
+ * @author Alessandro Parisi
+ */
+public class WorkspaceData {
+    private final File file;
+    private final Map<String, Map<String, String>> data;
+    private boolean isRelativePaths = false;
+
+    public WorkspaceData(File file, Map<String, Map<String, String>> data) {
+        this.file = Objects.requireNonNull(file, "Workspace file cannot be null!");
+        this.data = ofNullable(data).orElseGet(Hashtable::new);
+
+        try {
+            String s = getProperty("relative.paths");
+            isRelativePaths = Boolean.parseBoolean(s);
+        } catch (Exception ignored) {
+        }
+    }
+
+    public String getProperty(String key) {
+        return ofNullable(data.get(key)).map(Object::toString).orElse(null);
+    }
+
+    public ToolData getToolData(ToolBound tool) {
+        return new ToolData(isRelativePaths ? file : null, data.get(tool.toolBinding()));
+    }
+
+    public File file() {
+        return file;
+    }
+
+    public Map<String, Map<String, String>> data() {
+        return Collections.unmodifiableMap(data);
+    }
+
+    public static class ToolData {
+        private final File workspaceFile;
+        private final Map<String, String> data;
+
+        public ToolData() {
+            this(null, new HashMap<>());
+        }
+
+        public ToolData(File workspaceFile, Map<String, String> data) {
+            this.workspaceFile = workspaceFile;
+            this.data = Optional.ofNullable(data).orElseGet(HashMap::new);
+        }
+
+        public String get(String key) {
+            return data.get(key);
+        }
+
+        public String get(String key, String or) {
+            return ofNullable(data.get(key)).orElse(or);
+        }
+
+        public Integer getInt(String key, Integer or) {
+            return Optional.ofNullable(get(key)).map(Integer::parseInt).orElse(or);
+        }
+
+        public boolean getBoolean(String key) {
+            return Optional.ofNullable(get(key)).map(Boolean::parseBoolean).orElse(false);
+        }
+
+        public Path getPath(String key) {
+            Path toPath = Path.of(get(key, EMPTY));
+            if (workspaceFile == null || Files.exists(toPath))
+                return toPath;
+
+            try {
+                Path workspaceDir = workspaceFile.toPath().getParent();
+                toPath = workspaceDir.resolve(toPath.getFileName());
+                if (!Files.exists(toPath))
+                    return Path.of("");
+                return toPath;
+            } catch (Exception ex) {
+                return toPath;
+            }
+        }
+
+        public void set(String key, String value) {
+            data.put(key, value);
+        }
+
+        public void setBoolean(String key, boolean value) {
+            data.put(key, Boolean.toString(value));
+        }
+
+        public void setInt(String key, int value) {
+            data.put(key, Integer.toString(value));
+        }
+
+        public <E extends Enum<E>> void setEnum(String key, E value) {
+            if (value != null)
+                set(key, value.toString());
+        }
+
+        public boolean hasKey(String key) {
+            return data.containsKey(key);
+        }
+
+        public boolean isEmpty() {
+            return data.isEmpty();
+        }
+    }
+}

--- a/pdfsam-model/src/test/java/org/pdfsam/model/ui/workspace/LoadWorkspaceResponseTest.java
+++ b/pdfsam-model/src/test/java/org/pdfsam/model/ui/workspace/LoadWorkspaceResponseTest.java
@@ -34,9 +34,9 @@ class LoadWorkspaceResponseTest {
     @Test
     public void nullDataConstructor() {
         File file = mock(File.class);
-        LoadWorkspaceResponse victim = new LoadWorkspaceResponse(file, null);
-        assertNotNull(victim.getData("CHUCK"));
-        assertTrue(victim.getData("CHUCK").isEmpty());
+        WorkspaceData victim = new WorkspaceData(file, null);
+        assertNotNull(victim.getToolData(() -> "CHUCK"));
+        assertTrue(victim.getToolData(() -> "CHUCK").isEmpty());
     }
 
     @Test
@@ -46,8 +46,8 @@ class LoadWorkspaceResponseTest {
         Map<String, Map<String, String>> moduleData = new HashMap<>();
         moduleData.put("module", data);
         File file = mock(File.class);
-        LoadWorkspaceResponse victim = new LoadWorkspaceResponse(file, moduleData);
-        assertFalse(victim.getData("module").isEmpty());
+        WorkspaceData victim = new WorkspaceData(file, moduleData);
+        assertFalse(victim.getToolData(() -> "module").isEmpty());
     }
 
     @Test
@@ -57,8 +57,8 @@ class LoadWorkspaceResponseTest {
         Map<String, Map<String, String>> moduleData = new HashMap<>();
         moduleData.put("module", data);
         File file = mock(File.class);
-        LoadWorkspaceResponse victim = new LoadWorkspaceResponse(file, moduleData);
-        assertNotNull(victim.getData("CHUCK"));
-        assertTrue(victim.getData("CHUCK").isEmpty());
+        WorkspaceData victim = new WorkspaceData(file, moduleData);
+        assertNotNull(victim.getToolData(() -> "CHUCK"));
+        assertTrue(victim.getToolData(() -> "CHUCK").isEmpty());
     }
 }

--- a/pdfsam-service/src/main/java/org/pdfsam/service/ui/WorkspaceController.java
+++ b/pdfsam-service/src/main/java/org/pdfsam/service/ui/WorkspaceController.java
@@ -25,6 +25,7 @@ import org.pdfsam.model.tool.Tool;
 import org.pdfsam.model.ui.workspace.LoadWorkspaceRequest;
 import org.pdfsam.model.ui.workspace.LoadWorkspaceResponse;
 import org.pdfsam.model.ui.workspace.SaveWorkspaceRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.model.ui.workspace.WorkspaceLoadedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,7 @@ public class WorkspaceController {
     private final Collection<Tool> tools;
     private final WorkspaceService service;
     private final RecentWorkspacesService recentWorkspace;
+    private WorkspaceData workspace;
 
     @Inject
     WorkspaceController(WorkspaceService service, RecentWorkspacesService recentWorkspace) {
@@ -85,8 +87,9 @@ public class WorkspaceController {
             LOG.debug(i18n().tr("Loading workspace from {0}", event.workspace().getName()));
             try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
                 var data = service.loadWorkspace(event.workspace());
+                workspace = new WorkspaceData(event.workspace(), data);
                 if (!data.isEmpty()) {
-                    var response = new LoadWorkspaceResponse(event.workspace(), data);
+                    var response = new LoadWorkspaceResponse(workspace);
                     tools.forEach(m -> scope.fork(() -> {
                         eventStudio().broadcast(response, m.id());
                         return null;

--- a/pdfsam-tools/pdfsam-alternate-mix/src/main/java/org/pdfsam/tools/alternatemix/AlternateMixToolPanel.java
+++ b/pdfsam-tools/pdfsam-alternate-mix/src/main/java/org/pdfsam/tools/alternatemix/AlternateMixToolPanel.java
@@ -26,6 +26,8 @@ import javafx.scene.layout.VBox;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsablePdfOutputField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.support.Views;
@@ -64,20 +66,21 @@ public class AlternateMixToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         // backwards comp when alternate mix had 2 inputs
-        if (data.containsKey("firstDocumentMixinput")) {
-            data.put("input.0", data.get("firstDocumentMixinput"));
-            data.put("input.password.0", data.get("firstDocumentMixinputinput.password"));
-            data.put("input.step.0", data.get("firstStep"));
-            data.put("input.reverse.0", data.get("reverseFirst"));
-            data.put("input.size", "1");
-            if (data.containsKey("secondDocumentMixinput")) {
-                data.put("input.1", data.get("secondDocumentMixinput"));
-                data.put("input.password.1", data.get("secondDocumentMixinput.password"));
-                data.put("input.step.1", data.get("secondStep"));
-                data.put("input.reverse.1", data.get("reverseSecond"));
-                data.put("input.size", "2");
+        if (data.hasKey("firstDocumentMixinput")) {
+            data.set("input.0", data.getPath("firstDocumentMixinput").toString());
+            data.set("input.password.0", data.get("firstDocumentMixinputinput.password"));
+            data.set("input.step.0", data.get("firstStep"));
+            data.set("input.reverse.0", data.get("reverseFirst"));
+            data.setInt("input.size", 1);
+            if (data.hasKey("secondDocumentMixinput")) {
+                data.set("input.1", data.getPath("secondDocumentMixinput").toString());
+                data.set("input.password.1", data.get("secondDocumentMixinput.password"));
+                data.set("input.step.1", data.get("secondStep"));
+                data.set("input.reverse.1", data.get("reverseSecond"));
+                data.setInt("input.size", 2);
             }
         }
         selectionPane.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-backpages/src/main/java/org/pdfsam/tools/backpages/AddBackpagesPane.java
+++ b/pdfsam-tools/pdfsam-backpages/src/main/java/org/pdfsam/tools/backpages/AddBackpagesPane.java
@@ -27,6 +27,7 @@ import org.pdfsam.core.support.params.ConversionUtils;
 import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.selection.single.SingleSelectionPane;
 import org.pdfsam.ui.components.support.FXValidationSupport;
@@ -175,7 +176,7 @@ public class AddBackpagesPane extends VBox
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         backpagesSourceField.restoreStateFrom(data);
         range.setText(Optional.ofNullable(data.get("range.field")).orElse(EMPTY));
         pace.setText(Optional.ofNullable(data.get("pace.field")).orElse(EMPTY));

--- a/pdfsam-tools/pdfsam-backpages/src/main/java/org/pdfsam/tools/backpages/AddBackpagesToolPanel.java
+++ b/pdfsam-tools/pdfsam-backpages/src/main/java/org/pdfsam/tools/backpages/AddBackpagesToolPanel.java
@@ -25,6 +25,8 @@ import javafx.scene.layout.VBox;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsablePdfOutputField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.selection.single.TaskParametersBuilderSingleSelectionPane;
@@ -72,7 +74,8 @@ public class AddBackpagesToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         selectionPane.restoreStateFrom(data);
         addBackpagesOptions.restoreStateFrom(data);
         destinationFileField.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-backpages/src/test/java/org/pdfsam/tools/backpages/AddBackpagesPaneTest.java
+++ b/pdfsam-tools/pdfsam-backpages/src/test/java/org/pdfsam/tools/backpages/AddBackpagesPaneTest.java
@@ -80,7 +80,7 @@ class AddBackpagesPaneTest {
     @Test
     public void validRange() throws Exception {
         populate();
-        robot.clickOn("#selectedBackpages").type(KeyCode.DIGIT5, KeyCode.MINUS, KeyCode.DIGIT9).push(KeyCode.ENTER);
+        robot.clickOn("#selectedBackpages").write("5-9").push(KeyCode.ENTER);
         victim.apply(builder, onError);
         verify(builder).ranges(anySet());
         verify(onError, never()).accept(anyString());

--- a/pdfsam-tools/pdfsam-extract/src/main/java/org/pdfsam/tools/extract/ExtractOptionsPane.java
+++ b/pdfsam-tools/pdfsam-extract/src/main/java/org/pdfsam/tools/extract/ExtractOptionsPane.java
@@ -26,13 +26,13 @@ import javafx.scene.layout.GridPane;
 import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 import org.pdfsam.ui.components.support.Style;
 import org.sejda.conversion.exception.ConversionException;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -112,9 +112,9 @@ class ExtractOptionsPane extends GridPane
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        field.setText(Optional.ofNullable(data.get("pages")).orElse(EMPTY));
-        separateFile.setSelected(Boolean.parseBoolean(data.get("separateFile")));
+    public void restoreStateFrom(ToolData data) {
+        field.setText(data.get("pages", EMPTY));
+        separateFile.setSelected(data.getBoolean("separateFile"));
     }
 
     @Override

--- a/pdfsam-tools/pdfsam-extract/src/main/java/org/pdfsam/tools/extract/ExtractToolPanel.java
+++ b/pdfsam-tools/pdfsam-extract/src/main/java/org/pdfsam/tools/extract/ExtractToolPanel.java
@@ -27,6 +27,8 @@ import javafx.scene.layout.VBox;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsableOutputDirectoryField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.prefix.PrefixPane;
@@ -85,11 +87,12 @@ public class ExtractToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
-        if (data.containsKey("input")) {
-            data.put("input.0", data.get("input"));
-            data.put("input.password.0", data.get("input.password"));
-            data.put("input.size", "1");
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
+        if (data.hasKey("input")) {
+            data.set("input.0", data.getPath("input").toString());
+            data.set("input.password.0", data.get("input.password"));
+            data.setInt("input.size", 1);
         }
         selectionPane.restoreStateFrom(data);
         extractOptions.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-extract/src/test/java/org/pdfsam/tools/extract/ExtractOptionsPaneTest.java
+++ b/pdfsam-tools/pdfsam-extract/src/test/java/org/pdfsam/tools/extract/ExtractOptionsPaneTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.testfx.api.FxRobot;
@@ -100,7 +101,9 @@ public class ExtractOptionsPaneTest {
 
     @Test
     public void restoreState() {
-        var data = Map.of("pages", "100", "separateFile", Boolean.TRUE.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setInt("pages", 100);
+        data.setBoolean("separateFile", true);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         var field = robot.lookup("#extractRanges").queryAs(ValidableTextField.class);
         var separateFile = robot.lookup("#separateFile").queryAs(CheckBox.class);

--- a/pdfsam-tools/pdfsam-merge/src/main/java/org/pdfsam/tools/merge/MergeOptionsPane.java
+++ b/pdfsam-tools/pdfsam-merge/src/main/java/org/pdfsam/tools/merge/MergeOptionsPane.java
@@ -27,6 +27,7 @@ import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.model.ui.ComboItem;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.support.Style;
 import org.sejda.model.outline.OutlinePolicy;
 import org.sejda.model.pdf.form.AcroFormPolicy;
@@ -159,7 +160,7 @@ class MergeOptionsPane extends VBox
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         Optional.ofNullable(data.get("outline")).map(OutlinePolicy::valueOf)
                 .flatMap(key -> this.outline.getItems().stream().filter(i -> i.key().equals(key)).findFirst())
                 .ifPresent(this.outline.getSelectionModel()::select);
@@ -183,7 +184,7 @@ class MergeOptionsPane extends VBox
         this.pageNormalization.getItems().stream().filter(i -> i.key().equals(normalization)).findFirst()
                 .ifPresent(this.pageNormalization.getSelectionModel()::select);
 
-        blankIfOdd.setSelected(Boolean.parseBoolean(data.get("blankIfOdd")));
-        footer.setSelected(Boolean.parseBoolean(data.get("footer")));
+        blankIfOdd.setSelected(data.getBoolean("blankIfOdd"));
+        footer.setSelected(data.getBoolean("footer"));
     }
 }

--- a/pdfsam-tools/pdfsam-merge/src/main/java/org/pdfsam/tools/merge/MergeToolPanel.java
+++ b/pdfsam-tools/pdfsam-merge/src/main/java/org/pdfsam/tools/merge/MergeToolPanel.java
@@ -26,6 +26,8 @@ import javafx.scene.layout.VBox;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsablePdfOutputField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.tool.BaseToolPanel;
@@ -65,7 +67,8 @@ public class MergeToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         selectionPane.restoreStateFrom(data);
         mergeOptions.restoreStateFrom(data);
         destinationFileField.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-merge/src/test/java/org/pdfsam/tools/merge/MergeOptionsPaneTest.java
+++ b/pdfsam-tools/pdfsam-merge/src/test/java/org/pdfsam/tools/merge/MergeOptionsPaneTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.pdfsam.model.ui.ComboItem;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.sejda.model.outline.OutlinePolicy;
 import org.sejda.model.pdf.form.AcroFormPolicy;
@@ -108,13 +109,13 @@ public class MergeOptionsPaneTest {
         CheckBox blankIfOdd = robot.lookup("#blankIfOddCheck").queryAs(CheckBox.class);
         CheckBox footer = robot.lookup("#footerCheck").queryAs(CheckBox.class);
         ComboBox<ComboItem<PageNormalizationPolicy>> normalize = robot.lookup("#normalizeCheck").queryComboBox();
-        Map<String, String> data = new HashMap<>();
-        data.put("outline", OutlinePolicy.ONE_ENTRY_EACH_DOC.toString());
-        data.put("acroForms", AcroFormPolicy.MERGE_RENAMING_EXISTING_FIELDS.toString());
-        data.put("blankIfOdd", Boolean.FALSE.toString());
-        data.put("footer", Boolean.TRUE.toString());
-        data.put("pageNormalization", PageNormalizationPolicy.SAME_WIDTH_ORIENTATION_BASED.toString());
-        data.put("toc", ToCPolicy.DOC_TITLES.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setEnum("outline", OutlinePolicy.ONE_ENTRY_EACH_DOC);
+        data.setEnum("acroForms", AcroFormPolicy.MERGE_RENAMING_EXISTING_FIELDS);
+        data.setBoolean("blankIfOdd", false);
+        data.setBoolean("footer", true);
+        data.setEnum("pageNormalization", PageNormalizationPolicy.SAME_WIDTH_ORIENTATION_BASED);
+        data.setEnum("toc", ToCPolicy.DOC_TITLES);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(OutlinePolicy.ONE_ENTRY_EACH_DOC, outline.getSelectionModel().getSelectedItem().key());
         assertEquals(AcroFormPolicy.MERGE_RENAMING_EXISTING_FIELDS, forms.getSelectionModel().getSelectedItem().key());
@@ -128,8 +129,8 @@ public class MergeOptionsPaneTest {
     @Test
     public void restoreNormalizationStateBackwardCompatible() {
         ComboBox<ComboItem<PageNormalizationPolicy>> normalize = robot.lookup("#normalizeCheck").queryComboBox();
-        Map<String, String> data = new HashMap<>();
-        data.put("normalize", Boolean.TRUE.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setBoolean("normalize", true);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(PageNormalizationPolicy.SAME_WIDTH_ORIENTATION_BASED,
                 normalize.getSelectionModel().getSelectedItem().key());
@@ -143,13 +144,13 @@ public class MergeOptionsPaneTest {
         CheckBox blankIfOdd = robot.lookup("#blankIfOddCheck").queryAs(CheckBox.class);
         CheckBox footer = robot.lookup("#footerCheck").queryAs(CheckBox.class);
         ComboBox<ComboItem<PageNormalizationPolicy>> normalize = robot.lookup("#normalizeCheck").queryComboBox();
-        Map<String, String> data = new HashMap<>();
-        data.put("outline", OutlinePolicy.ONE_ENTRY_EACH_DOC.toString());
-        data.put("acroForms", AcroFormPolicy.FLATTEN.toString());
-        data.put("blankIfOdd", Boolean.TRUE.toString());
-        data.put("footer", Boolean.TRUE.toString());
-        data.put("pageNormalization", PageNormalizationPolicy.SAME_WIDTH_ORIENTATION_BASED.toString());
-        data.put("toc", ToCPolicy.DOC_TITLES.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setEnum("outline", OutlinePolicy.ONE_ENTRY_EACH_DOC);
+        data.setEnum("acroForms", AcroFormPolicy.FLATTEN);
+        data.setBoolean("blankIfOdd", true);
+        data.setBoolean("footer", true);
+        data.setEnum("pageNormalization", PageNormalizationPolicy.SAME_WIDTH_ORIENTATION_BASED);
+        data.setEnum("toc", ToCPolicy.DOC_TITLES);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(OutlinePolicy.ONE_ENTRY_EACH_DOC, outline.getSelectionModel().getSelectedItem().key());
         assertEquals(AcroFormPolicy.FLATTEN, forms.getSelectionModel().getSelectedItem().key());

--- a/pdfsam-tools/pdfsam-rotate/src/main/java/org/pdfsam/tools/rotate/RotateOptionsPane.java
+++ b/pdfsam-tools/pdfsam-rotate/src/main/java/org/pdfsam/tools/rotate/RotateOptionsPane.java
@@ -25,6 +25,7 @@ import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.model.ui.ComboItem;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.support.Style;
 import org.sejda.model.pdf.page.PredefinedSetOfPages;
 import org.sejda.model.rotation.Rotation;
@@ -87,7 +88,7 @@ class RotateOptionsPane extends HBox
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         Optional.ofNullable(data.get("rotation")).map(Rotation::valueOf)
                 .flatMap(key -> this.rotation.getItems().stream().filter(i -> i.key().equals(key)).findFirst())
                 .ifPresent(this.rotation.getSelectionModel()::select);

--- a/pdfsam-tools/pdfsam-rotate/src/main/java/org/pdfsam/tools/rotate/RotateToolPanel.java
+++ b/pdfsam-tools/pdfsam-rotate/src/main/java/org/pdfsam/tools/rotate/RotateToolPanel.java
@@ -27,6 +27,8 @@ import javafx.scene.layout.VBox;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsableOutputDirectoryField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.prefix.PrefixPane;
@@ -83,7 +85,8 @@ public class RotateToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         selectionPane.restoreStateFrom(data);
         rotateOptions.restoreStateFrom(data);
         destinationPane.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-rotate/src/test/java/org/pdfsam/tools/rotate/RotateOptionsPaneTest.java
+++ b/pdfsam-tools/pdfsam-rotate/src/test/java/org/pdfsam/tools/rotate/RotateOptionsPaneTest.java
@@ -24,6 +24,7 @@ import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.pdfsam.model.ui.ComboItem;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.sejda.model.pdf.page.PredefinedSetOfPages;
 import org.sejda.model.rotation.Rotation;
@@ -84,9 +85,9 @@ public class RotateOptionsPaneTest   {
     public void restoreStateFrom() {
         ComboBox<ComboItem<PredefinedSetOfPages>> rotationType = robot.lookup("#rotationType").queryComboBox();
         ComboBox<ComboItem<Rotation>> rotation = robot.lookup("#rotation").queryComboBox();
-        Map<String, String> data = new HashMap<>();
-        data.put("rotation", Rotation.DEGREES_270.toString());
-        data.put("rotationType", PredefinedSetOfPages.EVEN_PAGES.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setEnum("rotation", Rotation.DEGREES_270);
+        data.setEnum("rotationType", PredefinedSetOfPages.EVEN_PAGES);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(Rotation.DEGREES_270, rotation.getSelectionModel().getSelectedItem().key());
         assertEquals(PredefinedSetOfPages.EVEN_PAGES, rotationType.getSelectionModel().getSelectedItem().key());
@@ -96,9 +97,9 @@ public class RotateOptionsPaneTest   {
     public void reset() {
         ComboBox<ComboItem<PredefinedSetOfPages>> rotationType = robot.lookup("#rotationType").queryComboBox();
         ComboBox<ComboItem<Rotation>> rotation = robot.lookup("#rotation").queryComboBox();
-        Map<String, String> data = new HashMap<>();
-        data.put("rotation", Rotation.DEGREES_270.toString());
-        data.put("rotationType", PredefinedSetOfPages.EVEN_PAGES.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setEnum("rotation", Rotation.DEGREES_270);
+        data.setEnum("rotationType", PredefinedSetOfPages.EVEN_PAGES);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(Rotation.DEGREES_270, rotation.getSelectionModel().getSelectedItem().key());
         assertEquals(PredefinedSetOfPages.EVEN_PAGES, rotationType.getSelectionModel().getSelectedItem().key());

--- a/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitAfterPredefinedSetOfPagesRadioButton.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitAfterPredefinedSetOfPagesRadioButton.java
@@ -24,6 +24,7 @@ import org.pdfsam.core.support.params.SplitParametersBuilder;
 import org.pdfsam.model.ui.ComboItem;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.sejda.model.parameter.SimpleSplitParameters;
 import org.sejda.model.pdf.page.PredefinedSetOfPages;
 
@@ -78,8 +79,8 @@ class SplitAfterPredefinedSetOfPagesRadioButton extends RadioButton
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        Optional.ofNullable(data.get("splitAfterPredefined")).map(Boolean::valueOf).ifPresent(this::setSelected);
+    public void restoreStateFrom(ToolData data) {
+        setSelected(data.getBoolean("splitAfterPredefined"));
         Optional.ofNullable(data.get("splitAfterPredefined.combo")).map(PredefinedSetOfPages::valueOf)
                 .flatMap(key -> this.combo.getItems().stream().filter(i -> i.key().equals(key)).findFirst())
                 .ifPresent(this.combo.getSelectionModel()::select);

--- a/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitAfterRadioButton.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitAfterRadioButton.java
@@ -23,6 +23,7 @@ import org.pdfsam.core.support.params.SplitParametersBuilder;
 import org.pdfsam.core.support.validation.Validators;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 import org.sejda.conversion.PageNumbersListAdapter;
@@ -30,7 +31,6 @@ import org.sejda.model.parameter.SplitByPagesParameters;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -77,9 +77,9 @@ class SplitAfterRadioButton extends RadioButton
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        Optional.ofNullable(data.get("splitAfter")).map(Boolean::valueOf).ifPresent(this::setSelected);
-        field.setText(Optional.ofNullable(data.get("splitAfter.field")).orElse(EMPTY));
+    public void restoreStateFrom(ToolData data) {
+        setSelected(data.getBoolean("splitAfter"));
+        field.setText(data.get("splitAfter.field", EMPTY));
     }
 
     @Override

--- a/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitByEveryRadioButton.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitByEveryRadioButton.java
@@ -23,12 +23,12 @@ import org.pdfsam.core.support.params.SplitParametersBuilder;
 import org.pdfsam.core.support.validation.Validators;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 import org.sejda.model.parameter.SplitByEveryXPagesParameters;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -75,9 +75,9 @@ public class SplitByEveryRadioButton extends RadioButton
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        Optional.ofNullable(data.get("splitByEvery")).map(Boolean::valueOf).ifPresent(this::setSelected);
-        field.setText(Optional.ofNullable(data.get("splitByEvery.field")).orElse(EMPTY));
+    public void restoreStateFrom(ToolData data) {
+        setSelected(data.getBoolean("splitByEvery"));
+        field.setText(data.get("splitByEvery.field", EMPTY));
     }
 
     void setMaxPages(Integer value) {

--- a/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitOptionsPane.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitOptionsPane.java
@@ -25,6 +25,7 @@ import org.pdfsam.core.support.params.SinglePdfSourceMultipleOutputParametersBui
 import org.pdfsam.model.ui.ComboItem;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.RadioButtonDrivenTextFieldsPane;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.Style;
@@ -95,7 +96,7 @@ class SplitOptionsPane extends VBox implements SplitParametersBuilderCreator, Re
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         splitAfterPredefined.restoreStateFrom(data);
         splitAfter.restoreStateFrom(data);
         splitByEvery.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitToolPanel.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitToolPanel.java
@@ -28,6 +28,8 @@ import org.pdfsam.core.support.params.SinglePdfSourceMultipleOutputParametersBui
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsableOutputDirectoryField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.prefix.PrefixPane;
@@ -80,7 +82,8 @@ public class SplitToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         selectionPane.restoreStateFrom(data);
         splitOptions.restoreStateFrom(data);
         destinationDirectoryField.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-simple-split/src/test/java/org/pdfsam/tools/split/SplitAfterPredefinedSetOfPagesRadioButtonTest.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/test/java/org/pdfsam/tools/split/SplitAfterPredefinedSetOfPagesRadioButtonTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.pdfsam.core.ConfigurableSystemProperty;
 import org.pdfsam.model.ui.ComboItem;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.sejda.model.input.PdfFileSource;
 import org.sejda.model.optimization.OptimizationPolicy;
@@ -163,9 +164,9 @@ public class SplitAfterPredefinedSetOfPagesRadioButtonTest {
     @Test
     public void restoreState() {
         ComboBox<ComboItem<PredefinedSetOfPages>> combo = robot.lookup("#combo").queryComboBox();
-        Map<String, String> data = new HashMap<>();
-        data.put("splitAfterPredefined", Boolean.TRUE.toString());
-        data.put("splitAfterPredefined.combo", PredefinedSetOfPages.EVEN_PAGES.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setBoolean("splitAfterPredefined", true);
+        data.setEnum("splitAfterPredefined.combo", PredefinedSetOfPages.EVEN_PAGES);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertTrue(victim.isSelected());
         assertEquals(PredefinedSetOfPages.EVEN_PAGES, combo.getSelectionModel().getSelectedItem().key());

--- a/pdfsam-tools/pdfsam-simple-split/src/test/java/org/pdfsam/tools/split/SplitAfterRadioButtonTest.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/test/java/org/pdfsam/tools/split/SplitAfterRadioButtonTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.tools.split.SplitAfterRadioButton.SplitByPageParametersBuilder;
 import org.pdfsam.ui.components.commons.ValidableTextField;
@@ -181,9 +182,9 @@ public class SplitAfterRadioButtonTest {
     @Test
     public void restoreState() {
         ValidableTextField field =  robot.lookup("#field").queryAs(ValidableTextField.class);
-        Map<String, String> data = new HashMap<>();
-        data.put("splitAfter", Boolean.TRUE.toString());
-        data.put("splitAfter.field", "chuck");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setBoolean("splitAfter", true);
+        data.set("splitAfter.field", "chuck");
         victim.restoreStateFrom(data);
         assertTrue(victim.isSelected());
         assertEquals("chuck", field.getText());

--- a/pdfsam-tools/pdfsam-simple-split/src/test/java/org/pdfsam/tools/split/SplitByEveryRadioButtonTest.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/test/java/org/pdfsam/tools/split/SplitByEveryRadioButtonTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
@@ -166,9 +167,9 @@ public class SplitByEveryRadioButtonTest {
     @Test
     public void restoreState() {
         ValidableTextField field = robot.lookup("#field").queryAs(ValidableTextField.class);
-        Map<String, String> data = new HashMap<>();
-        data.put("splitByEvery", Boolean.TRUE.toString());
-        data.put("splitByEvery.field", "chuck");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setBoolean("splitByEvery", true);
+        data.set("splitByEvery.field", "chuck");
         victim.restoreStateFrom(data);
         assertTrue(victim.isSelected());
         assertEquals("chuck", field.getText());

--- a/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/BookmarksLevelComboBox.java
+++ b/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/BookmarksLevelComboBox.java
@@ -24,6 +24,7 @@ import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.core.support.validation.Validators;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.support.FXValidationSupport;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 import org.pdfsam.ui.components.support.Style;
@@ -36,11 +37,12 @@ import java.util.stream.IntStream;
 
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.pdfsam.i18n.I18nContext.i18n;
 
 /**
  * Combo box letting the user specify the filesize in the split by size task
- * 
+ *
  * @author Andrea Vacondio
  *
  */
@@ -60,7 +62,7 @@ class BookmarksLevelComboBox extends ComboBox<String>
                 getEditor().getStyleClass().removeAll(Style.INVALID.css());
             }
         });
-      
+
     }
 
     public void setValidBookmarkLevels(SortedSet<Integer> levels) {
@@ -111,11 +113,12 @@ class BookmarksLevelComboBox extends ComboBox<String>
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         getSelectionModel().selectFirst();
-        ofNullable(data.get("levelCombo.max")).map(Integer::valueOf).ifPresent(max -> IntStream.rangeClosed(1, max).mapToObj(Integer::toString).forEach(getItems()::add));
+        ofNullable(data.getInt("levelCombo.max", null)).ifPresent(
+                max -> IntStream.rangeClosed(1, max).mapToObj(Integer::toString).forEach(getItems()::add));
         Arrays.stream(ofNullable(data.get("levelCombo.levels")).map(l -> l.split(",")).orElse(new String[0]))
                 .forEach(getItems()::add);
-        setValue(ofNullable(data.get("levelCombo.selected")).orElse(""));
+        setValue(data.get("levelCombo.selected", EMPTY));
     }
 }

--- a/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/SplitByBookmarksToolPanel.java
+++ b/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/SplitByBookmarksToolPanel.java
@@ -27,6 +27,8 @@ import org.apache.commons.lang3.builder.Builder;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsableOutputDirectoryField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.prefix.PrefixPane;
@@ -78,7 +80,8 @@ public class SplitByBookmarksToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         selectionPane.restoreStateFrom(data);
         splitOptions.restoreStateFrom(data);
         destinationDirectoryField.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/SplitOptionsPane.java
+++ b/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/SplitOptionsPane.java
@@ -28,10 +28,10 @@ import javafx.scene.layout.HBox;
 import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.support.Style;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.SortedSet;
 import java.util.function.Consumer;
 
@@ -115,8 +115,8 @@ class SplitOptionsPane extends GridPane
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        regexpField.setText(Optional.ofNullable(data.get("regexp")).orElse(EMPTY));
+    public void restoreStateFrom(ToolData data) {
+        regexpField.setText(data.get("regexp", EMPTY));
         levelCombo.restoreStateFrom(data);
     }
 }

--- a/pdfsam-tools/pdfsam-split-by-bookmarks/src/test/java/org/pdfsam/tools/splitbybookmarks/BookmarksLevelComboBoxTest.java
+++ b/pdfsam-tools/pdfsam-split-by-bookmarks/src/test/java/org/pdfsam/tools/splitbybookmarks/BookmarksLevelComboBoxTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 import org.pdfsam.ui.components.support.Style;
@@ -175,9 +176,9 @@ public class BookmarksLevelComboBoxTest {
     @Test
     public void restoreState() {
         victim.setValidBookmarkLevels(new TreeSet<>(Arrays.asList(40, 50)));
-        Map<String, String> data = new HashMap<>();
-        data.put("levelCombo.levels", "2,3,5,6,7,10");
-        data.put("levelCombo.selected", "2");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("levelCombo.levels", "2,3,5,6,7,10");
+        data.setInt("levelCombo.selected", 2);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals("2", victim.getValue());
         assertThat(victim.getItems()).contains("2", "3", "5", "6", "7", "10");
@@ -197,9 +198,9 @@ public class BookmarksLevelComboBoxTest {
     @Test
     public void restoreStateBackwardCompatible() {
         victim.setValidBookmarkLevels(new TreeSet<>(Arrays.asList(40, 50)));
-        Map<String, String> data = new HashMap<>();
-        data.put("levelCombo.max", "3");
-        data.put("levelCombo.selected", "2");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setInt("levelCombo.max", 3);
+        data.setInt("levelCombo.selected", 2);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals("2", victim.getValue());
         assertThat(victim.getItems()).contains("1", "2", "3");
@@ -208,8 +209,8 @@ public class BookmarksLevelComboBoxTest {
     @Test
     public void restoreStateEmptySelected() {
         victim.setValidBookmarkLevels(validLevels);
-        Map<String, String> data = new HashMap<>();
-        data.put("levelCombo.selected", "");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("levelCombo.selected", "");
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals("", victim.getValue());
     }
@@ -217,8 +218,8 @@ public class BookmarksLevelComboBoxTest {
     @Test
     public void restoreStateNullSelected() {
         victim.setValidBookmarkLevels(validLevels);
-        Map<String, String> data = new HashMap<>();
-        data.put("levelCombo.selected", null);
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("levelCombo.selected", null);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals("", victim.getValue());
     }

--- a/pdfsam-tools/pdfsam-split-by-bookmarks/src/test/java/org/pdfsam/tools/splitbybookmarks/SplitOptionsPaneTest.java
+++ b/pdfsam-tools/pdfsam-split-by-bookmarks/src/test/java/org/pdfsam/tools/splitbybookmarks/SplitOptionsPaneTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
@@ -131,10 +132,10 @@ public class SplitOptionsPaneTest {
 
     @Test
     public void restoreState() {
-        Map<String, String> data = new HashMap<>();
-        data.put("regexp", "Chuck");
-        data.put("levelCombo.selected", "2");
-        data.put("levelCombo.levels", "2,3,5,6,7,10");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("regexp", "Chuck");
+        data.set("levelCombo.selected", "2");
+        data.set("levelCombo.levels", "2,3,5,6,7,10");
         victim.restoreStateFrom(data);
         TextInputControl field = robot.lookup("#bookmarksRegexp").queryTextInputControl();
         assertEquals("Chuck", field.getText());

--- a/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SizeUnitRadio.java
+++ b/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SizeUnitRadio.java
@@ -20,9 +20,9 @@ package org.pdfsam.tools.splitbysize;
 
 import javafx.scene.control.RadioButton;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
 
@@ -50,8 +50,8 @@ class SizeUnitRadio extends RadioButton implements RestorableView {
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        Optional.ofNullable(data.get(unit.toString())).map(Boolean::valueOf).ifPresent(this::setSelected);
+    public void restoreStateFrom(ToolData data) {
+        setSelected(data.getBoolean(unit.toString()));
     }
 
     public SizeUnit unit() {

--- a/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SplitBySizeToolPanel.java
+++ b/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SplitBySizeToolPanel.java
@@ -27,6 +27,8 @@ import org.apache.commons.lang3.builder.Builder;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ClearToolRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.io.BrowsableOutputDirectoryField;
 import org.pdfsam.ui.components.io.PdfDestinationPane;
 import org.pdfsam.ui.components.prefix.PrefixPane;
@@ -77,7 +79,8 @@ public class SplitBySizeToolPanel extends BaseToolPanel {
     }
 
     @Override
-    public void onLoadWorkspace(Map<String, String> data) {
+    public void onLoadWorkspace(WorkspaceData workspace) {
+        ToolData data = workspace.getToolData(this);
         selectionPane.restoreStateFrom(data);
         splitOptions.restoreStateFrom(data);
         destinationDirectoryField.restoreStateFrom(data);

--- a/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SplitOptionsPane.java
+++ b/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SplitOptionsPane.java
@@ -25,13 +25,13 @@ import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.core.support.validation.Validators;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 import org.pdfsam.ui.components.support.Style;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -85,8 +85,8 @@ class SplitOptionsPane extends HBox
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        field.setText(Optional.ofNullable(data.get("size")).orElse(EMPTY));
+    public void restoreStateFrom(ToolData data) {
+        field.setText(data.get("size", EMPTY));
         group.getToggles().stream().map(t -> (SizeUnitRadio) t).forEach(s -> s.restoreStateFrom(data));
     }
 

--- a/pdfsam-tools/pdfsam-split-by-size/src/test/java/org/pdfsam/tools/splitbysize/SizeUnitRadioTest.java
+++ b/pdfsam-tools/pdfsam-split-by-size/src/test/java/org/pdfsam/tools/splitbysize/SizeUnitRadioTest.java
@@ -20,6 +20,7 @@ package org.pdfsam.tools.splitbysize;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.JavaFxThreadInitializeExtension;
 
 import java.util.HashMap;
@@ -62,8 +63,8 @@ public class SizeUnitRadioTest {
     public void onRestoreState() {
         SizeUnitRadio victim = new SizeUnitRadio(SizeUnit.MEGABYTE);
         victim.setSelected(false);
-        Map<String, String> data = new HashMap<>();
-        data.put(SizeUnit.MEGABYTE.toString(), Boolean.TRUE.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setBoolean(SizeUnit.MEGABYTE.toString(), true);
         victim.restoreStateFrom(data);
         assertTrue(victim.isSelected());
     }

--- a/pdfsam-tools/pdfsam-split-by-size/src/test/java/org/pdfsam/tools/splitbysize/SplitOptionsPaneTest.java
+++ b/pdfsam-tools/pdfsam-split-by-size/src/test/java/org/pdfsam/tools/splitbysize/SplitOptionsPaneTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
@@ -104,9 +105,9 @@ public class SplitOptionsPaneTest {
     public void restoreState() {
         SizeUnitRadio kilo = robot.lookup("#unit" + SizeUnit.KILOBYTE.symbol()).queryAs(SizeUnitRadio.class);
         SizeUnitRadio mega = robot.lookup("#unit" + SizeUnit.MEGABYTE.symbol()).queryAs(SizeUnitRadio.class);
-        Map<String, String> data = new HashMap<>();
-        data.put("size", "100");
-        data.put(SizeUnit.MEGABYTE.toString(), Boolean.TRUE.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setInt("size", 100);
+        data.setBoolean(SizeUnit.MEGABYTE.toString(), true);
         victim.restoreStateFrom(data);
         TextInputControl field = robot.lookup("#sizeField").queryTextInputControl();
         assertEquals("100", field.getText());

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/BrowsableField.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/BrowsableField.java
@@ -25,6 +25,7 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ValidableTextField;
 import org.pdfsam.ui.components.support.FXValidationSupport;
 import org.pdfsam.ui.components.support.Style;
@@ -33,7 +34,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.defaultString;
@@ -109,8 +109,8 @@ abstract class BrowsableField extends HBox implements RestorableView {
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        textField.setText(Optional.ofNullable(data.get(defaultString(getId()) + "browsableField")).orElse(EMPTY));
+    public void restoreStateFrom(ToolData data) {
+        textField.setText(data.get(defaultString(getId()) + "browsableField", EMPTY));
     }
 
     public final void setGraphic(Node value) {

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/PdfDestinationPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/PdfDestinationPane.java
@@ -33,6 +33,7 @@ import org.pdfsam.model.ui.DefaultPdfVersionComboItem;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.SetDestinationRequest;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.support.Style;
 import org.pdfsam.ui.components.support.Views;
 import org.sejda.model.output.ExistingOutputPolicy;
@@ -166,11 +167,11 @@ public class PdfDestinationPane extends DestinationPane implements ToolBound, Re
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         version.resetView();
-        compress.setSelected(Boolean.parseBoolean(data.get("compress")));
-        overwrite().setSelected(Boolean.parseBoolean(data.get("overwrite")));
-        discardBookmarks.ifPresent(d -> d.setSelected(Boolean.parseBoolean(data.get("discardBookmarks"))));
+        compress.setSelected(data.getBoolean("compress"));
+        overwrite().setSelected(data.getBoolean("overwrite"));
+        discardBookmarks.ifPresent(d -> d.setSelected(data.getBoolean("discardBookmarks")));
         ofNullable(data.get("version")).map(PdfVersion::valueOf).map(DefaultPdfVersionComboItem::new)
                 .ifPresent(v -> this.version.getSelectionModel().select(v));
     }

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/prefix/PrefixPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/prefix/PrefixPane.java
@@ -29,12 +29,12 @@ import org.pdfsam.model.tool.TaskExecutionRequest;
 import org.pdfsam.model.tool.ToolBound;
 import org.pdfsam.model.ui.ResettableView;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.persistence.PreferencesRepository;
 import org.pdfsam.ui.components.support.Style;
 import org.sejda.model.prefix.Prefix;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -126,8 +126,8 @@ public class PrefixPane extends GridPane
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
-        field.setText(Optional.ofNullable(data.get(defaultString(getId()) + "prefix")).orElse(EMPTY));
+    public void restoreStateFrom(ToolData data) {
+        field.setText(data.get(defaultString(getId()) + "prefix", EMPTY));
     }
 
 }

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/MultipleSelectionPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/MultipleSelectionPane.java
@@ -30,6 +30,7 @@ import org.pdfsam.model.pdf.PdfLoadRequest;
 import org.pdfsam.model.tool.ClearToolRequest;
 import org.pdfsam.model.tool.ToolBound;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.selection.RemoveSelectedEvent;
 import org.sejda.model.parameter.base.TaskParameters;
 
@@ -103,7 +104,7 @@ public class MultipleSelectionPane extends BorderPane implements ToolBound, Rest
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         table.restoreStateFrom(data);
     }
 

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/SelectionTable.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/SelectionTable.java
@@ -66,6 +66,7 @@ import org.pdfsam.model.ui.ShowPdfDescriptorRequest;
 import org.pdfsam.model.ui.ShowStageRequest;
 import org.pdfsam.model.ui.dnd.FilesDroppedEvent;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.selection.PasswordFieldPopup;
 import org.pdfsam.ui.components.selection.RemoveSelectedEvent;
 import org.pdfsam.ui.components.selection.SetPageRangesRequest;
@@ -76,7 +77,6 @@ import org.pdfsam.ui.components.selection.multiple.move.SelectionAndFocus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -590,23 +590,23 @@ public class SelectionTable extends TableView<SelectionTableRowData> implements 
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         onClear(null);
-        int size = Optional.ofNullable(data.get(defaultString(getId()) + "input.size")).map(Integer::valueOf).orElse(0);
+        String id = defaultString(getId());
+        int size = data.getInt(id + "input.size", 0);
         if (size > 0) {
             PdfLoadRequest loadEvent = new PdfLoadRequest(toolBinding());
             List<SelectionTableRowData> items = new ArrayList<>();
             IntStream.range(0, size).forEach(i -> {
-                String id = defaultString(getId());
-                Optional.ofNullable(data.get(id + "input." + i)).ifPresent(f -> {
-                    PdfDocumentDescriptor descriptor = PdfDocumentDescriptor.newDescriptor(new File(f),
+                Optional.ofNullable(data.getPath(id + "input." + i)).ifPresent(p -> {
+                    PdfDocumentDescriptor descriptor = PdfDocumentDescriptor.newDescriptor(p.toFile(),
                             ofNullable(data.get(id + "input.password.enc" + i)).map(EncryptionUtils::decrypt)
-                                    .orElseGet(() -> data.get(defaultString(getId()) + "input.password." + i)));
+                                    .orElseGet(() -> data.get(id + "input.password." + i)));
                     loadEvent.add(descriptor);
                     SelectionTableRowData row = new SelectionTableRowData(descriptor);
                     row.pageSelection.set(data.get(id + "input.range." + i));
                     row.pace.set(data.get(id + "input.step." + i));
-                    row.reverse.set(Boolean.parseBoolean(data.get(id + "input.reverse." + i)));
+                    row.reverse.set(data.getBoolean(id + "input.reverse." + i));
                     items.add(row);
                 });
             });

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/single/SingleSelectionPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/single/SingleSelectionPane.java
@@ -59,6 +59,7 @@ import org.pdfsam.model.ui.ShowLogMessagesRequest;
 import org.pdfsam.model.ui.ShowPdfDescriptorRequest;
 import org.pdfsam.model.ui.ShowStageRequest;
 import org.pdfsam.model.ui.workspace.RestorableView;
+import org.pdfsam.model.ui.workspace.WorkspaceData.ToolData;
 import org.pdfsam.ui.components.commons.ToggleChangeListener;
 import org.pdfsam.ui.components.io.BrowsableFileField;
 import org.pdfsam.ui.components.selection.LoadingStatusIndicatorUpdater;
@@ -261,15 +262,16 @@ public class SingleSelectionPane extends VBox implements ToolBound, PdfDocumentD
     }
 
     @Override
-    public void restoreStateFrom(Map<String, String> data) {
+    public void restoreStateFrom(ToolData data) {
         getField().getTextField().setText(EMPTY);
-        Optional.ofNullable(data.get(defaultString(getId()) + "input")).ifPresent(f -> {
+        String id = defaultString(getId());
+        Optional.ofNullable(data.getPath(id + "input")).ifPresent(p -> {
             onValidState.disabled(true);
-            getField().getTextField().setText(f);
+            getField().getTextField().setText(p.toString());
             onValidState.disabled(false);
-            initializeFor(newDescriptor(new File(f),
-                    ofNullable(data.get(defaultString(getId()) + "input.password.enc")).map(EncryptionUtils::decrypt)
-                            .orElseGet(() -> data.get(defaultString(getId()) + "input.password"))));
+            initializeFor(newDescriptor(p.toFile(),
+                    ofNullable(data.get(id + "input.password.enc")).map(EncryptionUtils::decrypt)
+                            .orElseGet(() -> data.get(id + "input.password"))));
         });
     }
 

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/tool/BaseToolPanel.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/tool/BaseToolPanel.java
@@ -29,6 +29,7 @@ import org.pdfsam.model.tool.Tool;
 import org.pdfsam.model.tool.ToolBound;
 import org.pdfsam.model.ui.workspace.LoadWorkspaceResponse;
 import org.pdfsam.model.ui.workspace.SaveWorkspaceRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.ui.components.notification.AddNotificationRequest;
 import org.pdfsam.ui.components.notification.NotificationType;
 import org.pdfsam.ui.components.support.Style;
@@ -87,7 +88,7 @@ public abstract class BaseToolPanel extends BorderPane implements ToolBound {
 
     @EventListener
     public final void restoreState(LoadWorkspaceResponse event) {
-        Platform.runLater(() -> onLoadWorkspace(event.getData(toolBinding())));
+        Platform.runLater(() -> onLoadWorkspace(event.data()));
     }
 
     /**
@@ -100,9 +101,9 @@ public abstract class BaseToolPanel extends BorderPane implements ToolBound {
     /**
      * Request to restore the module state using the provided data.
      *
-     * @param data
+     * @param workspace
      */
-    public abstract void onLoadWorkspace(Map<String, String> data);
+    public abstract void onLoadWorkspace(WorkspaceData workspace);
 
     @EventListener
     public void onRunButtonAccelerator(RunButtonTriggerRequest request) {

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/io/BrowsableFileFieldTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/io/BrowsableFileFieldTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.pdfsam.i18n.SetLocaleRequest;
 import org.pdfsam.model.io.FileType;
 import org.pdfsam.model.io.OpenType;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.JavaFxThreadExtension;
 import org.pdfsam.ui.components.support.FXValidationSupport.ValidationState;
 
@@ -173,8 +174,8 @@ public class BrowsableFileFieldTest {
     public void restoreState() {
         BrowsableFileField victim = new BrowsableFileField(FileType.PDF, OpenType.SAVE);
         victim.setId("fieldId");
-        Map<String, String> data = new HashMap<>();
-        data.put("fieldIdbrowsableField", "/some/file/test.pdf");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("fieldIdbrowsableField", "/some/file/test.pdf");
         victim.restoreStateFrom(data);
         assertEquals("/some/file/test.pdf", victim.getTextField().getText());
     }

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/io/PdfDestinationPaneTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/io/PdfDestinationPaneTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import org.pdfsam.core.context.BooleanPersistentProperty;
 import org.pdfsam.model.ui.PdfVersionComboItem;
 import org.pdfsam.model.ui.SetDestinationRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.test.JavaFxThreadInitializeExtension;
 import org.sejda.model.pdf.PdfVersion;
@@ -134,10 +135,10 @@ public class PdfDestinationPaneTest {
 
     @Test
     public void restoreState() {
-        Map<String, String> data = new HashMap<>();
-        data.put("overwrite", Boolean.FALSE.toString());
-        data.put("compress", Boolean.TRUE.toString());
-        data.put("version", PdfVersion.VERSION_1_4.toString());
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setBoolean("overwrite", false);
+        data.setBoolean("compress", true);
+        data.setEnum("version", PdfVersion.VERSION_1_4);
         victim.restoreStateFrom(data);
         assertFalse(victim.overwrite().isSelected());
     }

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/prefix/PrefixPaneTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/prefix/PrefixPaneTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.pdfsam.core.context.StringPersistentProperty;
 import org.pdfsam.core.support.params.MultipleOutputTaskParametersBuilder;
 import org.pdfsam.model.tool.TaskExecutionRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.persistence.PreferencesRepository;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.sejda.model.parameter.base.AbstractParameters;
@@ -112,8 +113,8 @@ public class PrefixPaneTest {
 
     @Test
     public void restoreState() {
-        Map<String, String> data = new HashMap<>();
-        data.put("victimprefix", "Chuck");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("victimprefix", "Chuck");
         victim.restoreStateFrom(data);
         assertEquals("Chuck", victim.getText());
     }

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/multiple/SelectionTableTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/multiple/SelectionTableTest.java
@@ -52,6 +52,7 @@ import org.pdfsam.model.tool.ClearToolRequest;
 import org.pdfsam.model.ui.SetDestinationRequest;
 import org.pdfsam.model.ui.ShowLogMessagesRequest;
 import org.pdfsam.model.ui.ShowPdfDescriptorRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.test.HitTestListener;
 import org.pdfsam.ui.components.selection.RemoveSelectedEvent;
@@ -236,10 +237,10 @@ public class SelectionTableTest {
         eventStudio().clear();
         Listener<PdfLoadRequest> listener = mock(Listener.class);
         eventStudio().add(PdfLoadRequest.class, listener);
-        Map<String, String> data = new HashMap<>();
-        data.put("victiminput.size", "1");
-        data.put("victiminput.0", "chuck.pdf");
-        data.put("victiminput.password.0", "pwd");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.setInt("victiminput.size", 1);
+        data.set("victiminput.0", "chuck.pdf");
+        data.set("victiminput.password.0", "pwd");
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(1, victim.getItems().size());
         SelectionTableRowData first = victim.getItems().get(0);
@@ -251,14 +252,14 @@ public class SelectionTableTest {
         eventStudio().clear();
         Listener<PdfLoadRequest> listener = mock(Listener.class);
         eventStudio().add(PdfLoadRequest.class, listener);
-        Map<String, String> data = new HashMap<>();
-        data.put("victiminput.size", "2");
-        data.put("victiminput.0", "chuck.pdf");
-        data.put("victiminput.password.enc0", EncryptionUtils.encrypt("pwd"));
-        data.put("victiminput.range.0", "1-10");
-        data.put("victiminput.step.0", "4");
-        data.put("victiminput.reverse.0", "true");
-        data.put("victiminput.1", "norris.pdf");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("victiminput.size", "2");
+        data.set("victiminput.0", "chuck.pdf");
+        data.set("victiminput.password.enc0", EncryptionUtils.encrypt("pwd"));
+        data.set("victiminput.range.0", "1-10");
+        data.set("victiminput.step.0", "4");
+        data.set("victiminput.reverse.0", "true");
+        data.set("victiminput.1", "norris.pdf");
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(2, victim.getItems().size());
         SelectionTableRowData first = victim.getItems().get(0);
@@ -277,15 +278,15 @@ public class SelectionTableTest {
 
     @Test
     public void restoreStateFromEmpty() {
-        Map<String, String> data = new HashMap<>();
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertTrue(victim.getItems().isEmpty());
     }
 
     @Test
     public void restoreStateFromSizeZero() {
-        Map<String, String> data = new HashMap<>();
-        data.put("victiminput.size", "0");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("victiminput.size", "0");
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertTrue(victim.getItems().isEmpty());
     }

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/single/SingleSelectionPaneTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/single/SingleSelectionPaneTest.java
@@ -43,6 +43,7 @@ import org.pdfsam.model.ui.ChangedSelectedPdfVersionEvent;
 import org.pdfsam.model.ui.SetDestinationRequest;
 import org.pdfsam.model.ui.ShowLogMessagesRequest;
 import org.pdfsam.model.ui.ShowPdfDescriptorRequest;
+import org.pdfsam.model.ui.workspace.WorkspaceData;
 import org.pdfsam.test.ClearEventStudioExtension;
 import org.pdfsam.test.HitConsumer;
 import org.pdfsam.test.HitTestListener;
@@ -313,9 +314,9 @@ public class SingleSelectionPaneTest {
     public void restoreStateFromPwdBackwardCompatible() {
         Listener<PdfLoadRequest> listener = mock(Listener.class);
         eventStudio().add(PdfLoadRequest.class, listener);
-        Map<String, String> data = new HashMap<>();
-        data.put("victim-selection-paneinput", "chuck.pdf");
-        data.put("victim-selection-paneinput.password", "pwd");
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("victim-selection-paneinput", "chuck.pdf");
+        data.set("victim-selection-paneinput.password", "pwd");
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals("chuck.pdf", victim.getField().getTextField().getText());
         assertEquals("pwd", victim.getPdfDocumentDescriptor().getPassword());
@@ -326,9 +327,9 @@ public class SingleSelectionPaneTest {
     public void restoreStateFrom() {
         Listener<PdfLoadRequest> listener = mock(Listener.class);
         eventStudio().add(PdfLoadRequest.class, listener);
-        Map<String, String> data = new HashMap<>();
-        data.put("victim-selection-paneinput", "chuck.pdf");
-        data.put("victim-selection-paneinput.password.enc", EncryptionUtils.encrypt("pwd"));
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
+        data.set("victim-selection-paneinput", "chuck.pdf");
+        data.set("victim-selection-paneinput.password.enc", EncryptionUtils.encrypt("pwd"));
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals("chuck.pdf", victim.getField().getTextField().getText());
         assertEquals("pwd", victim.getPdfDocumentDescriptor().getPassword());
@@ -338,7 +339,7 @@ public class SingleSelectionPaneTest {
     @Test
     public void restoreStateFromEmpty() throws Exception {
         moveToLoadedState(victim);
-        Map<String, String> data = new HashMap<>();
+        WorkspaceData.ToolData data = new WorkspaceData.ToolData();
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertTrue(isEmpty(victim.getField().getTextField().getText()));
     }


### PR DESCRIPTION
This PR aims at reworking the workspace API, moving from a generic map of strings to a dedicated class that manages both reads and writes in a safe and typed way.

### Details:
1) The `WorkspaceController` loads a workspace JSON file and keeps a reference to the current loaded workspace, which is a dedicated class: `WorkspaceData`.
2) Then it sends the event to all the tools to restore their state from the workspace data. The `LoadWorkspaceResponse` has been changed to carry the `WorkspaceData` instead of the file and the "plain" data.
3) Since PDFSam uses nested maps to carry states to each individual tool, there's another dedicated class inside `WorkspaceData` which is: `ToolData`. This class wraps the workspace file and the specific tool data as a `Map<String, String>`. A tool can retrieve its state from the workspace data by calling `workspaceData.getToolData(this)`. I preferred this way rather than having a generic `getToolData(String toolId)` method which may be error prone, less secure.
4) In `BaseToolPanel`, the `onLoadWorkspace(...)` method has been changed to accept the `WorkspaceData` instance. Each tool panel retrieves the tool data via the aforementioned method and calls `restoreStateFrom(...)` on its subcomponents (the `AlternateMixToolPanel` being an exception since it also manipulates the data for backwards compatibility)
5) The `restoreStateFrom(...)` method from `RestorableView` has also been changed to accept `ToolData` rather than a generic map

### Flow
`WorkspaceController` -> `LoadWorkspaceResponse(WorkspaceData)` -> `BaseToolPanel(WorkspaceData -> ToolData)` -> `RestorableView(ToolData)`

### Summary
All in all, `WorkspaceData` and `ToolData` are just wrappers for plain, generic maps. In fact, the goal of the first commit was to preserve as much as possible of the existing code, while just moving the logic to a single place so that it can more easily be tested, managed, changed.

#### Three more things to note:
1) The first commit says 'Part 1' because for, now only the loading API has been reworked. The save API still accepts maps.
2) `WorkspaceData` already implements an enhancement for issue #710, and as requested it's not a fallback system, but expects a `relative.paths` property to be set to `true` in the workspace file. Since `ToolData` is responsible for resolving the paths (because it's the class carrying the data to the specific tool), the wrapped workspace file determines if the relative path resolution is enabled. If the file is null, then it's disabled.
3) This enhancement follows a similar path as PR #763, which defines a separate class to keep track of the loaded workspace and its hash. We could consider merging that PR here.