### PR TITLE
Fix PdfListParser to take into account ending quotes

### DIFF
--- a/pdfsam-service/src/test/java/org/pdfsam/service/pdf/PdfListParserTest.java
+++ b/pdfsam-service/src/test/java/org/pdfsam/service/pdf/PdfListParserTest.java
@@ -76,6 +76,19 @@ public class PdfListParserTest {
     }
 
     @Test
+    public void applyPathsWithQuotes(@TempDir Path folder) throws IOException {
+        var file1 = Files.createTempFile(folder, null, "Hello World.pdf").toFile();
+        var file2 = Files.createTempFile(folder, null, "Hello, World.pdf").toFile();
+        var list = folder.resolve("list.csv");
+        List<String> lines = new ArrayList<>();
+        lines.add(file1.getAbsolutePath());
+        lines.add("\"" + file2.getAbsolutePath() + "\"");
+        Files.write(list, lines);
+        List<File> parsed = new PdfListParser().apply(list);
+        assertThat(parsed).containsExactly(file1, file2);
+    }
+
+    @Test
     public void filenameWithQuotes(@TempDir Path folder) throws IOException {
         var file1 = Files.createFile(folder.resolve("file\"with quotes.pdf")).toFile();
         var list = folder.resolve("list.csv");


### PR DESCRIPTION
The `parseLine(String)` method of `PdfListParser` was not taking into account the ending quotes of fields wrapped in quotes.

Slightly improved performance too by removing some operations from the stream.

Unit test included.

Addresses issue #770