### PR TITLE
Cleanup code of TooltippedTextFieldTableCell

### DIFF
--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/ReverseColumn.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/multiple/ReverseColumn.java
@@ -34,6 +34,7 @@ public class ReverseColumn implements TableColumnProvider<Boolean> {
     public String getColumnTitle() {
         return i18n().tr("Reverse");
     }
+
     @Override
     public TableColumn<SelectionTableRowData, Boolean> getTableColumn() {
         TableColumn<SelectionTableRowData, Boolean> tableColumn = new TableColumn<>(getColumnTitle());

--- a/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/multiple/SelectionTableTest.java
+++ b/pdfsam-ui-components/src/test/java/org/pdfsam/ui/components/selection/multiple/SelectionTableTest.java
@@ -33,7 +33,6 @@ import javafx.stage.Stage;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -618,7 +617,6 @@ public class SelectionTableTest {
     }
 
     @Test
-    @Disabled("TODO")
     public void editCommitOnFocusLost() {
         Optional<SelectionTableRowData> item = victim.getItems().stream()
                 .filter(i -> "temp.pdf".equals(i.descriptor().getFileName())).findFirst();


### PR DESCRIPTION
This commit reviewed the code of the Tooltipped TextFieldTableCell, which implemented a workaround for issue #61 ([JBS Reference](https://bugs.openjdk.org/browse/JDK-8089514))

The focus/commit handling is still flawed, but something changed and the old code was causing other issues as reported in #783

I also re-enable an already present test for the issue: `SelectionTableTest.editCommitOnFocusLost()`

The code should be reviewed once again when [JDK-8089514](https://bugs.openjdk.org/browse/JDK-8089514) is available.