### PR TITLE
Feat: Auto output directory naming and removed confirmation pop-up

### DIFF
--- a/pdfsam-model/src/main/java/org/pdfsam/model/ui/SetOutputDirectoryRequest.java
+++ b/pdfsam-model/src/main/java/org/pdfsam/model/ui/SetOutputDirectoryRequest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the PDF Split And Merge source code
+ * Created on 13/nov/2025
+ * Copyright 2025 by Sober Lemur S.r.l. (info@soberlemur.com).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pdfsam.model.ui;
+
+import java.io.File;
+
+import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
+
+/**
+ * Request to set an output directory using the given file as footprint.
+ * The directory will be created based on the input file name (without extension).
+ *
+ * @author Andrea Vacondio
+ */
+public record SetOutputDirectoryRequest(File directory, boolean fallback) {
+
+    /**
+     * @param footprint input file to use for generating the output directory name
+     * @return a request to set the output directory based on the footprint file name
+     */
+    public static SetOutputDirectoryRequest requestOutputDirectory(File footprint) {
+        requireNotNullArg(footprint, "Footprint file cannot be null");
+        String nameWithoutExtension = getNameWithoutExtension(footprint.getName());
+        return new SetOutputDirectoryRequest(new File(footprint.getParent(), nameWithoutExtension), false);
+    }
+
+    /**
+     * @param footprint input file to use for generating the output directory name
+     * @return a request to set the output directory as fallback based on the footprint file name
+     */
+    public static SetOutputDirectoryRequest requestFallbackOutputDirectory(File footprint) {
+        requireNotNullArg(footprint, "Footprint file cannot be null");
+        String nameWithoutExtension = getNameWithoutExtension(footprint.getName());
+        return new SetOutputDirectoryRequest(new File(footprint.getParent(), nameWithoutExtension), true);
+    }
+
+    /**
+     * Removes the file extension from a filename
+     */
+    private static String getNameWithoutExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf('.');
+        if (lastDotIndex > 0) {
+            return filename.substring(0, lastDotIndex);
+        }
+        return filename;
+    }
+}

--- a/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitTool.java
+++ b/pdfsam-tools/pdfsam-simple-split/src/main/java/org/pdfsam/tools/split/SplitTool.java
@@ -85,7 +85,7 @@ public class SplitTool implements Tool {
         @Provides
         @Named(TOOL_ID + "field")
         public BrowsableOutputDirectoryField destinationDirectoryField() {
-            return new BrowsableOutputDirectoryField();
+            return new BrowsableOutputDirectoryField(TOOL_ID);
         }
 
         @Provides

--- a/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/SplitByBookmarksTool.java
+++ b/pdfsam-tools/pdfsam-split-by-bookmarks/src/main/java/org/pdfsam/tools/splitbybookmarks/SplitByBookmarksTool.java
@@ -91,7 +91,7 @@ public class SplitByBookmarksTool implements Tool {
         @Provides
         @Named(TOOL_ID + "field")
         public BrowsableOutputDirectoryField destinationDirectoryField() {
-            return new BrowsableOutputDirectoryField();
+            return new BrowsableOutputDirectoryField(TOOL_ID);
         }
 
         @Provides

--- a/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SplitBySizeTool.java
+++ b/pdfsam-tools/pdfsam-split-by-size/src/main/java/org/pdfsam/tools/splitbysize/SplitBySizeTool.java
@@ -85,7 +85,7 @@ public class SplitBySizeTool implements Tool {
         @Provides
         @Named(TOOL_ID + "field")
         public BrowsableOutputDirectoryField destinationDirectoryField() {
-            BrowsableOutputDirectoryField field = new BrowsableOutputDirectoryField();
+            BrowsableOutputDirectoryField field = new BrowsableOutputDirectoryField(TOOL_ID);
             field.setId(TOOL_ID + "field");
             return field;
         }

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/BrowsableOutputDirectoryField.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/BrowsableOutputDirectoryField.java
@@ -19,9 +19,14 @@
 package org.pdfsam.ui.components.io;
 
 import org.pdfsam.core.context.ApplicationContext;
+import org.pdfsam.core.context.BooleanPersistentProperty;
 import org.pdfsam.core.support.params.MultipleOutputTaskParametersBuilder;
 import org.pdfsam.core.support.params.TaskParametersBuildStep;
+import org.pdfsam.eventstudio.annotation.EventListener;
+import org.pdfsam.eventstudio.annotation.EventStation;
+import org.pdfsam.model.tool.ToolBound;
 import org.pdfsam.model.ui.NonExistingOutputDirectoryEvent;
+import org.pdfsam.model.ui.SetOutputDirectoryRequest;
 import org.pdfsam.ui.components.support.FXValidationSupport;
 import org.sejda.model.parameter.base.SingleOrMultipleOutputTaskParameters;
 
@@ -29,6 +34,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.pdfsam.core.context.ApplicationContext.app;
 import static org.pdfsam.core.context.StringPersistentProperty.WORKING_PATH;
 import static org.pdfsam.core.support.validation.Validators.and;
@@ -43,15 +50,42 @@ import static org.sejda.model.output.FileOrDirectoryTaskOutput.directory;
  * @author Andrea Vacondio
  */
 public class BrowsableOutputDirectoryField extends BrowsableDirectoryField
-        implements TaskParametersBuildStep<MultipleOutputTaskParametersBuilder<?>> {
+        implements TaskParametersBuildStep<MultipleOutputTaskParametersBuilder<?>>, ToolBound {
+
+    private String ownerModule = "";
 
     public BrowsableOutputDirectoryField() {
-        this(app());
+        this(app(), "");
+    }
+
+    public BrowsableOutputDirectoryField(String ownerModule) {
+        this(app(), ownerModule);
     }
 
     BrowsableOutputDirectoryField(ApplicationContext context) {
+        this(context, "");
+    }
+
+    BrowsableOutputDirectoryField(ApplicationContext context, String ownerModule) {
+        super();
+        this.ownerModule = defaultString(ownerModule);
+        eventStudio().addAnnotatedListeners(this);
         context.persistentSettings().get(WORKING_PATH).ifPresent(getTextField()::setText);
         getTextField().setValidator(and(nonBlank(), v -> !Files.isRegularFile(Paths.get(v))));
+    }
+
+    @EventListener
+    public void setOutputDirectory(SetOutputDirectoryRequest event) {
+        if (!event.fallback() || isBlank(getTextField().getText()) || app().persistentSettings()
+                .get(BooleanPersistentProperty.SMART_OUTPUT)) {
+            getTextField().setText(event.directory().getAbsolutePath());
+        }
+    }
+
+    @Override
+    @EventStation
+    public String toolBinding() {
+        return ownerModule;
     }
 
     @Override

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/BrowsableOutputDirectoryField.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/BrowsableOutputDirectoryField.java
@@ -18,6 +18,7 @@
  */
 package org.pdfsam.ui.components.io;
 
+import javafx.scene.control.Label;
 import org.pdfsam.core.context.ApplicationContext;
 import org.pdfsam.core.context.BooleanPersistentProperty;
 import org.pdfsam.core.support.params.MultipleOutputTaskParametersBuilder;
@@ -25,17 +26,21 @@ import org.pdfsam.core.support.params.TaskParametersBuildStep;
 import org.pdfsam.eventstudio.annotation.EventListener;
 import org.pdfsam.eventstudio.annotation.EventStation;
 import org.pdfsam.model.tool.ToolBound;
-import org.pdfsam.model.ui.NonExistingOutputDirectoryEvent;
 import org.pdfsam.model.ui.SetOutputDirectoryRequest;
 import org.pdfsam.ui.components.support.FXValidationSupport;
+import org.pdfsam.ui.components.support.Style;
 import org.sejda.model.parameter.base.SingleOrMultipleOutputTaskParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.pdfsam.core.context.ApplicationContext.app;
 import static org.pdfsam.core.context.StringPersistentProperty.WORKING_PATH;
 import static org.pdfsam.core.support.validation.Validators.and;
@@ -52,7 +57,9 @@ import static org.sejda.model.output.FileOrDirectoryTaskOutput.directory;
 public class BrowsableOutputDirectoryField extends BrowsableDirectoryField
         implements TaskParametersBuildStep<MultipleOutputTaskParametersBuilder<?>>, ToolBound {
 
+    private static final Logger LOG = LoggerFactory.getLogger(BrowsableOutputDirectoryField.class);
     private String ownerModule = "";
+    private final Label infoLabel = new Label();
 
     public BrowsableOutputDirectoryField() {
         this(app(), "");
@@ -72,6 +79,33 @@ public class BrowsableOutputDirectoryField extends BrowsableDirectoryField
         eventStudio().addAnnotatedListeners(this);
         context.persistentSettings().get(WORKING_PATH).ifPresent(getTextField()::setText);
         getTextField().setValidator(and(nonBlank(), v -> !Files.isRegularFile(Paths.get(v))));
+
+        // Setup info label
+        infoLabel.getStyleClass().addAll("info-message");
+        infoLabel.setStyle("-fx-text-fill: #2E7D32; -fx-padding: 2 0 0 2;");
+        infoLabel.setManaged(false);
+        infoLabel.setVisible(false);
+
+        // Add listener to show/hide info message
+        getTextField().textProperty().addListener((obs, oldVal, newVal) -> updateInfoLabel());
+    }
+
+    private void updateInfoLabel() {
+        if (isNotBlank(getTextField().getText())) {
+            var path = Paths.get(getTextField().getText());
+            if (!Files.exists(path)) {
+                infoLabel.setText(i18n().tr("Folder will be created"));
+                infoLabel.setManaged(true);
+                infoLabel.setVisible(true);
+                return;
+            }
+        }
+        infoLabel.setManaged(false);
+        infoLabel.setVisible(false);
+    }
+
+    public Label getInfoLabel() {
+        return infoLabel;
     }
 
     @EventListener
@@ -79,6 +113,7 @@ public class BrowsableOutputDirectoryField extends BrowsableDirectoryField
         if (!event.fallback() || isBlank(getTextField().getText()) || app().persistentSettings()
                 .get(BooleanPersistentProperty.SMART_OUTPUT)) {
             getTextField().setText(event.directory().getAbsolutePath());
+            updateInfoLabel();
         }
     }
 
@@ -94,9 +129,19 @@ public class BrowsableOutputDirectoryField extends BrowsableDirectoryField
         getTextField().validate();
         if (getTextField().getValidationState() == FXValidationSupport.ValidationState.VALID) {
             var output = Paths.get(getTextField().getText());
+
+            // Auto-create directory if it doesn't exist
             if (!Files.exists(output)) {
-                eventStudio().broadcast(new NonExistingOutputDirectoryEvent(output));
+                try {
+                    Files.createDirectories(output);
+                    LOG.debug("Created output directory {}", output);
+                } catch (IOException e) {
+                    LOG.warn("Unable to create output directory", e);
+                    onError.accept(i18n().tr("Unable to create output directory: {0}", e.getMessage()));
+                    return;
+                }
             }
+
             if (Files.isDirectory(output)) {
                 builder.output(directory(output.toFile()));
             } else {

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/DestinationPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/io/DestinationPane.java
@@ -48,7 +48,14 @@ class DestinationPane extends VBox implements ResettableView {
         overwrite.getStyleClass().addAll(Style.WITH_HELP.css());
 
        // destination.getStyleClass().addAll(Style.VITEM.css());
-        getChildren().addAll(destination, overwrite);
+        getChildren().add(destination);
+
+        // Add info label for BrowsableOutputDirectoryField
+        if (destination instanceof BrowsableOutputDirectoryField dirField) {
+            getChildren().add(dirField.getInfoLabel());
+        }
+
+        getChildren().add(overwrite);
         getStyleClass().addAll(Style.CONTAINER.css());
         getStyleClass().addAll(Style.VCONTAINER.css());
     }

--- a/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/single/SingleSelectionPane.java
+++ b/pdfsam-ui-components/src/main/java/org/pdfsam/ui/components/selection/single/SingleSelectionPane.java
@@ -85,6 +85,7 @@ import static org.pdfsam.model.pdf.PdfDocumentDescriptor.newDescriptor;
 import static org.pdfsam.model.pdf.PdfDocumentDescriptor.newDescriptorNoPassword;
 import static org.pdfsam.model.ui.SetDestinationRequest.requestDestination;
 import static org.pdfsam.model.ui.SetDestinationRequest.requestFallbackDestination;
+import static org.pdfsam.model.ui.SetOutputDirectoryRequest.requestFallbackOutputDirectory;
 
 /**
  * Panel letting the user select a single input PDF document
@@ -103,6 +104,7 @@ public class SingleSelectionPane extends VBox implements ToolBound, PdfDocumentD
 
     private Consumer<PdfDocumentDescriptor> onLoaded = d -> {
         eventStudio().broadcast(requestFallbackDestination(d.getFile(), toolBinding()), toolBinding());
+        eventStudio().broadcast(requestFallbackOutputDirectory(d.getFile()), toolBinding());
         eventStudio().broadcast(new ChangedSelectedPdfVersionEvent(d.getVersion()), toolBinding());
     };
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of output directories in the PDFsam application, focusing on better user experience and robustness when specifying or creating output folders. The main enhancements include a new request class for setting output directories, improved UI feedback when a directory will be created, automatic directory creation if it does not exist, and consistent handling across multiple tools.

As illustrated, when target directory is not existing, a green hint will be given. At run, no more pop-up will be given, improving continuous user experience. 

<img width="625" height="559" alt="Screenshot 2025-11-13 at 1 26 05 PM" src="https://github.com/user-attachments/assets/be03b87b-fbc2-41b0-a449-3c6e19e0435d" />


Tested on macOS.






Key changes:

**Output Directory Handling and API:**
* Added a new `SetOutputDirectoryRequest` record in `org.pdfsam.model.ui` to encapsulate requests for setting output directories, including support for fallback behavior and utility methods for generating directory names based on input files.
* Updated `SingleSelectionPane` to broadcast a fallback output directory request when a PDF is loaded, ensuring downstream components can respond appropriately. [[1]](diffhunk://#diff-50b79246ee0fa0605bd56d48305fa3223e2ad5b02e71383b0ce0587ecb74881cR88) [[2]](diffhunk://#diff-50b79246ee0fa0605bd56d48305fa3223e2ad5b02e71383b0ce0587ecb74881cR107)

**UI/UX Enhancements:**
* Enhanced `BrowsableOutputDirectoryField` to display an info label when the specified output directory does not exist, informing the user that the folder will be created. [[1]](diffhunk://#diff-95648b29e651fced5086a7f7bc3087d010276312d8333038ac4184ea91b235b0L46-R123) [[2]](diffhunk://#diff-82ce0b92a544690d6d8290a377825b6109cc5d93f05f0acd826b18e1ee031c4dL51-R58)
* The info label is now added to the `DestinationPane` UI when using a `BrowsableOutputDirectoryField`.

**Robustness and Consistency:**
* Modified `BrowsableOutputDirectoryField` to automatically create the output directory if it does not exist, and to handle errors gracefully with user feedback.
* Updated tool modules (`SplitTool`, `SplitByBookmarksTool`, `SplitBySizeTool`) to instantiate `BrowsableOutputDirectoryField` with the tool ID for consistent event handling and tool binding. [[1]](diffhunk://#diff-652c85a8f21fb5690ddc2646c598ad61e41b853e6e92e5084cc51c7248059824L88-R88) [[2]](diffhunk://#diff-d828c43c6a730b8ade7ae9be2736144a62a100443745d460eeee56acf98c541fL94-R94) [[3]](diffhunk://#diff-b3a95c0e3b565595d5213d772751a38855b74c742892bc6debf71ac2b07d9dd5L88-R88)

These changes collectively improve the reliability and user-friendliness of output directory selection across the application.